### PR TITLE
Use the real size instead of the metadata one

### DIFF
--- a/sdgym/synthesizers/independent.py
+++ b/sdgym/synthesizers/independent.py
@@ -37,6 +37,7 @@ class IndependentSynthesizer(BaseSynthesizer):
                 data[:, i] = x.reshape([samples])
                 data[:, i] = data[:, i].clip(info['min'], info['max'])
             else:
-                data[:, i] = np.random.choice(np.arange(info['size']), samples, p=self.models[i])
+                size = len(self.models[i])
+                data[:, i] = np.random.choice(np.arange(size), samples, p=self.models[i])
 
         return data


### PR DESCRIPTION
Resolve #20 

Fix a problem in the `IndependentSynthesizer`, where the `size` of the categorical variable labels array indicated in the metadata was being used during sample instead of the actual amount of labels seen.
This worked in most cases, but failed in the `intrusion` dataset because of one particular label not beeing present in the training partition.