### PR TITLE
Raise a specific error for unsupported datasets

### DIFF
--- a/sdgym/errors.py
+++ b/sdgym/errors.py
@@ -2,8 +2,12 @@
 
 
 class SDGymError(Exception):
-    pass
+    """Known error that is contemplated in the SDGym workflows."""
 
 
 class SDGymTimeout(SDGymError):
-    pass
+    """The process took too long and reached a timeout."""
+
+
+class UnsupportedDataset(SDGymError):
+    """The Dataset is not supported by this Synthesizer."""


### PR DESCRIPTION
If a dataset has datetimes or null values, Legacy single table synthesizers do not support it, so a specific error should be raised.