### PR TITLE
Store result files to s3

### DIFF
--- a/sdgym/__main__.py
+++ b/sdgym/__main__.py
@@ -128,7 +128,7 @@ def _list_available(args):
 
 
 def _collect(args):
-    sdgym.collect.collect_results(args.input_path, args.output_file)
+    sdgym.collect.collect_results(args.input_path, args.output_file, args.aws_key, args.aws_secret)
 
 
 def _get_parser():
@@ -230,6 +230,10 @@ def _get_parser():
                          help='Path within which to look for sdgym results.')
     collect.add_argument('-o', '--output-file', type=str,
                          help='Output file containing the collected results.')
+    collect.add_argument('-ak', '--aws-key', type=str, required=False,
+                         help='Aws access key ID to use when reading datasets.')
+    collect.add_argument('-as', '--aws-secret', type=str, required=False,
+                         help='Aws secret access key to use when reading datasets.')
 
     return parser
 

--- a/sdgym/benchmark.py
+++ b/sdgym/benchmark.py
@@ -333,7 +333,8 @@ def run(synthesizers, datasets=None, datasets_path=None, modalities=None, bucket
         raise SDGymError("No valid Dataset/Synthesizer combination given")
 
     scores = pd.concat(scores)
+
     if output_path:
-        scores.to_csv(output_path, index=False)
+        write_csv(scores, output_path, aws_key, aws_secret)
 
     return scores

--- a/sdgym/benchmark.py
+++ b/sdgym/benchmark.py
@@ -17,6 +17,7 @@ from sdgym.datasets import get_dataset_paths, load_dataset, load_tables
 from sdgym.errors import SDGymError
 from sdgym.metrics import get_metrics
 from sdgym.progress import TqdmLogger, progress
+from sdgym.s3 import is_s3_path, write_csv, write_file
 from sdgym.synthesizers.base import Baseline
 from sdgym.utils import (
     build_synthesizer, format_exception, get_synthesizers_dict, import_object, used_memory)
@@ -153,7 +154,8 @@ def _run_job(args):
     # Reset random seed
     np.random.seed()
 
-    synthesizer, metadata, metrics, iteration, cache_dir, timeout, run_id = args
+    synthesizer, metadata, metrics, iteration, cache_dir, \
+        timeout, run_id, aws_key, aws_secret = args
 
     name = synthesizer['name']
     dataset_name = metadata._metadata['name']
@@ -183,14 +185,16 @@ def _run_job(args):
         scores['error'] = output['error']
 
     if cache_dir:
-        base_path = str(cache_dir / f'{name}_{dataset_name}_{iteration}_{run_id}')
+        cache_dir_name = str(cache_dir)
+        base_path = f'{cache_dir_name}/{name}_{dataset_name}_{iteration}_{run_id}'
         if scores is not None:
-            scores.to_csv(base_path + '_scores.csv', index=False)
+            write_csv(scores, f'{base_path}_scores.csv', aws_key, aws_secret)
         if 'synthetic_data' in output:
-            compress_pickle.dump(output['synthetic_data'], base_path + '.data.gz')
+            synthetic_data = compress_pickle.dumps(output['synthetic_data'], compression='gzip')
+            write_file(synthetic_data, f'{base_path}.data.gz', aws_key, aws_secret)
         if 'exception' in output:
-            with open(base_path + '_error.txt', 'w') as error_file:
-                error_file.write(output['exception'])
+            exception = output['exception'].encode('utf-8')
+            write_file(exception, f'{base_path}_error.txt', aws_key, aws_secret)
 
     return scores
 
@@ -288,7 +292,7 @@ def run(synthesizers, datasets=None, datasets_path=None, modalities=None, bucket
     datasets = get_dataset_paths(datasets, datasets_path, bucket, aws_key, aws_secret)
     run_id = os.getenv('RUN_ID') or str(uuid.uuid4())[:10]
 
-    if cache_dir:
+    if cache_dir and not is_s3_path(cache_dir):
         cache_dir = Path(cache_dir)
         os.makedirs(cache_dir, exist_ok=True)
 
@@ -307,6 +311,8 @@ def run(synthesizers, datasets=None, datasets_path=None, modalities=None, bucket
                         cache_dir,
                         timeout,
                         run_id,
+                        aws_key,
+                        aws_secret,
                     )
                     jobs.append(args)
 

--- a/sdgym/collect.py
+++ b/sdgym/collect.py
@@ -1,10 +1,7 @@
-import pathlib
-
-import pandas as pd
-import tqdm
+from sdgym.s3 import read_csv_from_path, write_csv
 
 
-def collect_results(input_path, output_file):
+def collect_results(input_path, output_file=None, aws_key=None, aws_secret=None):
     """Collect the results in the given input directory, and
     write all the results into one csv file.
 
@@ -16,20 +13,23 @@ def collect_results(input_path, output_file):
             If ``output_file`` is provided, the consolidated
             results will be written there. Otherwise, they
             will be written to ``input_path``/results.csv.
+        aws_key (str):
+            If an ``aws_key`` is provided, the given access
+            key id will be used to read from and/or write to
+            any s3 paths.
+        aws_secret (str):
+            If an ``aws_secret`` is provided, the given secret
+            access key will be used to read from and/or write to
+            any s3 paths.
     """
     print(f'Reading results from {input_path}')
-    run_path = pathlib.Path(input_path)
-
-    scores = []
-    for path in tqdm.tqdm(list(run_path.glob('**/*.csv'))):
-        scores.append(pd.read_csv(path))
-
-    scores = pd.concat(scores).drop_duplicates()
+    scores = read_csv_from_path(input_path, aws_key, aws_secret)
+    scores = scores.drop_duplicates()
 
     if output_file:
         output = output_file
     else:
-        output = run_path / 'results.csv'
+        output = f'{input_path}/results.csv'
 
     print(f'Storing results at {output}')
-    scores.to_csv(output, index=False)
+    write_csv(scores, output, aws_key, aws_secret)

--- a/sdgym/s3.py
+++ b/sdgym/s3.py
@@ -1,5 +1,10 @@
+import io
+import pathlib
+
 import boto3
 import botocore
+import pandas as pd
+import tqdm
 
 S3_PREFIX = 's3://'
 
@@ -144,3 +149,97 @@ def write_csv(data, path, aws_key, aws_secret):
     """
     contents = data.to_csv(index=False).encode('utf-8')
     write_file(contents, path, aws_key, aws_secret)
+
+
+def read_file(path, aws_key, aws_secret):
+    """Read file from path.
+
+    The path can either be a local path or an s3 directory.
+
+    Args:
+        path (str):
+            The path to the file.
+        aws_key (str):
+            The access key id that will be used to communicate with s3,
+            if provided.
+        aws_secret (str):
+            The secret access key that will be used to communicate with
+            s3, if provided.
+
+    Returns:
+        bytes:
+            The content of the file in bytes.
+    """
+    if is_s3_path(path):
+        s3 = get_s3_client(aws_key, aws_secret)
+        bucket_name, key = parse_s3_path(path)
+        obj = s3.get_object(Bucket=bucket_name, Key=key)
+        contents = obj['Body'].read()
+    else:
+        with open(path, 'r') as f:
+            contents = f.read().encode('utf-8')
+
+    return contents
+
+
+def read_csv(path, aws_key, aws_secret):
+    """Read csv file from path.
+
+    The path can either be a local path or an s3 directory.
+
+    Args:
+        path (str):
+            The path to the csv file.
+        aws_key (str):
+            The access key id that will be used to communicate with s3,
+            if provided.
+        aws_secret (str):
+            The secret access key that will be used to communicate with
+            s3, if provided.
+
+    Returns:
+        pandas.DataFrame:
+            A DataFrame containing the contents of the csv file.
+    """
+    contents = read_file(path, aws_key, aws_secret)
+    return pd.read_csv(io.BytesIO(contents))
+
+
+def read_csv_from_path(path, aws_key, aws_secret):
+    """Read all csv content within a path.
+
+    All csv content within a path will be read and returned in a
+    DataFrame. The path can be either local or an s3 directory.
+
+    args:
+        path (str):
+            The path to read from, which can be either local or an
+            s3 path.
+        aws_key (str):
+            The access key id that will be used to communicate with s3,
+            if provided.
+        aws_secret (str):
+            The secret access key that will be used to communicate with
+            s3, if provided.
+
+    Returns:
+        pandas.DataFrame:
+            A DataFrame of all the csv contents in the path.
+    """
+    csv_contents = []
+    if is_s3_path(path):
+        s3 = get_s3_client(aws_key, aws_secret)
+        bucket_name, key_prefix = parse_s3_path(path)
+        resp = s3.list_objects(Bucket=bucket_name, Prefix=key_prefix)
+        csv_files = [f for f in resp['Contents'] if f['Key'].endswith('.csv')]
+        for csv_file in csv_files:
+            csv_file_key = csv_file['Key']
+            csv_contents.append(
+                read_csv(f's3://{bucket_name}/{csv_file_key}', aws_key, aws_secret))
+
+    else:
+        run_path = pathlib.Path(path)
+        for csv_path in tqdm.tqdm(list(run_path.glob('**/*.csv'))):
+            csv_contents.append(pd.read_csv(csv_path))
+
+    return pd.concat(csv_contents)

--- a/sdgym/s3.py
+++ b/sdgym/s3.py
@@ -1,0 +1,146 @@
+import boto3
+import botocore
+
+S3_PREFIX = 's3://'
+
+
+def is_s3_path(path):
+    """Determine if the given path is an s3 path.
+
+    Args:
+        path (str):
+            The path, which might be an s3 path.
+
+    Returns:
+        bool:
+            A boolean representing if the path is an s3 path or not.
+    """
+    return isinstance(path, str) and S3_PREFIX in path
+
+
+def parse_s3_path(path):
+    """Parse a s3 path into the bucket and key prefix.
+
+    Args:
+        path (str):
+            The s3 path to parse. The expected format for the s3 path is
+            `s3://<bucket-name>/path/to/dir`.
+
+    Returns:
+        tuple:
+            A tuple containing (`bucket_name`, `key_prefix`) where `bucket_name`
+            is the name of the s3 bucket, and `key_prefix` is the remainder
+            of the s3 path.
+    """
+    bucket_parts = path.replace(S3_PREFIX, '').split('/')
+    bucket_name = bucket_parts[0]
+
+    key_prefix = ''
+    if len(bucket_parts) > 1:
+        key_prefix = '/'.join(bucket_parts[1:])
+
+    return bucket_name, key_prefix
+
+
+def get_s3_client(aws_key=None, aws_secret=None):
+    """Get the boto client for interfacing with AWS s3.
+
+    Args:
+        aws_key (str):
+            The access key id that will be used to communicate with
+            s3, if provided.
+        aws_secret (str):
+            The secret access key that will be used to communicate
+            with s3, if provided.
+
+    Returns:
+        boto3.session.Session.client:
+            The s3 client that can be used to read / write to s3.
+    """
+    if aws_key is not None and aws_secret is not None:
+        # credentials available
+        return boto3.client(
+            's3',
+            aws_access_key_id=aws_key,
+            aws_secret_access_key=aws_secret
+        )
+    else:
+        if boto3.Session().get_credentials():
+            # credentials available and will be detected automatically
+            config = None
+        else:
+            # no credentials available, make unsigned requests
+            config = botocore.config.Config(signature_version=botocore.UNSIGNED)
+
+        return boto3.client('s3', config=config)
+
+
+def write_file(contents, path, aws_key, aws_secret):
+    """Write a file to the given path with the given contents.
+
+    If the path is an s3 directory, we will use the given aws credentials
+    to write to s3.
+
+    Args:
+        contents (bytes):
+            The contents that will be written to the file.
+        path (str):
+            The path to write the file to, which can be either local
+            or an s3 path.
+        aws_key (str):
+            The access key id that will be used to communicate with s3,
+            if provided.
+        aws_secret (str):
+            The secret access key that will be used to communicate
+            with s3, if provided.
+
+    Returns:
+        none
+    """
+    content_encoding = ''
+    write_mode = 'w'
+    if path.endswith('gz') or path.endswith('gzip'):
+        content_encoding = 'gzip'
+        write_mode = 'wb'
+
+    if is_s3_path(path):
+        s3 = get_s3_client(aws_key, aws_secret)
+        bucket_name, key = parse_s3_path(path)
+        s3.put_object(
+            Bucket=bucket_name,
+            Key=key,
+            Body=contents,
+            ContentEncoding=content_encoding,
+        )
+    else:
+        with open(path, write_mode) as f:
+            if write_mode == 'w':
+                f.write(contents.decode('utf-8'))
+            else:
+                f.write(contents)
+
+
+def write_csv(data, path, aws_key, aws_secret):
+    """Write a csv file to the given path with the given contents.
+
+    If the path is an s3 directory, we will use the given aws credentials
+    to write to s3.
+
+    Args:
+        data (pandas.DataFrame):
+            The data that will be written to the csv file.
+        path (str):
+            The path to write the file to, which can be either local
+            or an s3 path.
+        aws_key (str):
+            The access key id that will be used to communicate with s3,
+            if provided.
+        aws_secret (str):
+            The secret access key that will be used to communicate
+            with s3, if provided.
+
+    Returns:
+        none
+    """
+    contents = data.to_csv(index=False).encode('utf-8')
+    write_file(contents, path, aws_key, aws_secret)

--- a/tests/unit/test_datasets.py
+++ b/tests/unit/test_datasets.py
@@ -16,7 +16,7 @@ class AnyConfigWith:
         return self.signature_version == other.signature_version
 
 
-@patch('sdgym.datasets.boto3')
+@patch('sdgym.s3.boto3')
 def test_download_dataset_public_bucket(boto3_mock, tmpdir):
     """Test the ``sdv.datasets.download_dataset`` method. It calls `download_dataset`
     with a dataset in a public bucket, and does not pass in any aws credentials.
@@ -74,7 +74,7 @@ def test_download_dataset_public_bucket(boto3_mock, tmpdir):
         assert dataset_file.read() == 'test_content'
 
 
-@patch('sdgym.datasets.boto3')
+@patch('sdgym.s3.boto3')
 def test_download_dataset_private_bucket(boto3_mock, tmpdir):
     """Test the ``sdv.datasets.download_dataset`` method. It calls `download_dataset`
     with a dataset in a private bucket and uses aws credentials.

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -1,0 +1,213 @@
+from unittest.mock import Mock, patch
+
+import pandas as pd
+
+from sdgym.s3 import is_s3_path, parse_s3_path, write_csv, write_file
+
+
+def test_is_s3_path_with_local_dir():
+    """Test the ``sdgym.s3.is_s3_path`` function with a local directory.
+
+    If the path is not an s3 path, it should return ``False``.
+
+    Input:
+    - path to a local directory
+
+    Output:
+    - False
+    """
+    # setup
+    path = 'path/to/local/dir'
+
+    # run
+    result = is_s3_path(path)
+
+    # asserts
+    assert not result
+
+
+def test_is_s3_path_with_s3_bucket():
+    """Test the ``sdgym.s3.is_s3_path`` function with an s3 directory.
+
+    If the path is an s3 path, it should return ``True``.
+
+    Input:
+    - path to an s3 directory
+
+    Output:
+    - True
+    """
+    # setup
+    path = 's3://my-bucket/my/path'
+
+    # run
+    result = is_s3_path(path)
+
+    # asserts
+    assert result
+
+
+def test_parse_s3_path_bucket_only():
+    """Test the ``sdgym.s3.parse_s3_path`` function with an s3 path.
+
+    If the s3 path contains only the bucket name, the returned tuple
+    should be ``(bucket_name, '')``.
+
+    Input:
+    - path to s3 bucket
+
+    Output:
+    - ('my-bucket', '')
+    """
+    # setup
+    expected_bucket_name = 'my-bucket'
+    expected_key_prefix = ''
+    path = f's3://{expected_bucket_name}/{expected_key_prefix}'
+
+    # run
+    bucket_name, key_prefix = parse_s3_path(path)
+
+    # asserts
+    assert bucket_name == expected_bucket_name
+    assert key_prefix == expected_key_prefix
+
+
+def test_parse_s3_path_bucket_and_dir_path():
+    """Test the `sdgym.s3.parse_s3_path`` function with an s3 path.
+
+    If the s3 path contains the bucket and a sub directory, the returned
+    tuple should be ``(bucket_name, subdirectory)``.
+
+    Input:
+    - path to s3 directory
+
+    Output:
+    - ('my-bucket', 'path/to/dir')
+    """
+    # setup
+    expected_bucket_name = 'my-bucket'
+    expected_key_prefix = 'path/to/dir'
+    path = f's3://{expected_bucket_name}/{expected_key_prefix}'
+
+    # run
+    bucket_name, key_prefix = parse_s3_path(path)
+
+    # asserts
+    assert bucket_name == expected_bucket_name
+    assert key_prefix == expected_key_prefix
+
+
+def test_write_file(tmpdir):
+    """Test the `sdgym.s3.write_file`` function with a local path.
+
+    If the path is a local path, a file with the correct
+    contents should be created at the specified path.
+
+    Input:
+    - contents of the local file
+    - path to the local file
+    - aws_key is None
+    - aws_secret is None
+
+    Output:
+    - None
+
+    Side effects:
+    - file creation at the specified path with the given contents
+    """
+    # setup
+    content_str = 'test_content'
+    path = f'{tmpdir}/test.txt'
+
+    # run
+    write_file(content_str.encode('utf-8'), path, None, None)
+
+    # asserts
+    with open(path, 'r') as f:
+        assert f.read() == content_str
+
+
+@patch('sdgym.s3.boto3')
+def test_write_file_s3(boto3_mock):
+    """Test the `sdgym.s3.write_file`` function with an s3 path.
+
+    If the path is an s3 path, a file with the given contents
+    should be created at the specified s3 path.
+
+    Input:
+    - contents of the s3 file
+    - path to the s3 file location
+    - aws_key for aws authentication
+    - aws_secret for aws authentication
+
+    Output:
+    - None
+
+    Side effects:
+    - s3 client creation with aws credentials (aws_key, aws_secret)
+    - s3 method call to create a file in the given bucket with the
+      given contents
+    """
+    # setup
+    content_str = 'test_content'
+    bucket_name = 'my-bucket'
+    key = 'test.txt'
+    path = f's3://{bucket_name}/{key}'
+    aws_key = 'my-key'
+    aws_secret = 'my-secret'
+
+    s3_mock = Mock()
+    boto3_mock.client.return_value = s3_mock
+
+    # run
+    write_file(content_str.encode('utf-8'), path, aws_key, aws_secret)
+
+    # asserts
+    boto3_mock.client.assert_called_once_with(
+        's3',
+        aws_access_key_id=aws_key,
+        aws_secret_access_key=aws_secret
+    )
+    s3_mock.put_object.assert_called_once_with(
+        Bucket=bucket_name,
+        Key=key,
+        Body=content_str.encode('utf-8'),
+        ContentEncoding='',
+    )
+
+
+@patch('sdgym.s3.write_file')
+def test_write_csv(write_file_mock):
+    """Test the ``sdgym.s3.write_csv`` function.
+
+    If ``write_csv`` is called with a DataFrame,
+    ``write_file`` should be called with the expected DataFrame
+    contents.
+
+    Input:
+    - data to be written to the csv file
+    - path of the desired csv file
+    - aws_key is None
+    - aws_secret is None
+
+    Output:
+    - None
+
+    Side effects:
+    - call to write_file with the correct contents and path
+    """
+    # setup
+    data = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
+    path = 'tmp/path'
+
+    # run
+    write_csv(data, path, None, None)
+
+    # asserts
+    expected_content = 'col1,col2\n1,3\n2,4\n'
+    write_file_mock.assert_called_once_with(
+        expected_content.encode('utf-8'),
+        path,
+        None,
+        None
+    )


### PR DESCRIPTION
If the user passes `cache_dir` as an `s3://<bucket-name>/path/to/dir` the scores, synthetic data, and error files are stored in the corresponding path of the given bucket. If `aws_key` and `aws_secret` are provided, they will be used to authenticate the s3 requests.

✅ Ran with aws credentials and a private s3 bucket, and verified that the results files were uploaded.

Resolve #81 