### PR TITLE
Allow output_path to be a s3 path

### DIFF
--- a/sdgym/benchmark.py
+++ b/sdgym/benchmark.py
@@ -333,7 +333,8 @@ def run(synthesizers, datasets=None, datasets_path=None, modalities=None, bucket
         raise SDGymError("No valid Dataset/Synthesizer combination given")
 
     scores = pd.concat(scores)
+
     if output_path:
-        scores.to_csv(output_path, index=False)
+        write_csv(scores, output_path, aws_key, aws_secret)
 
     return scores


### PR DESCRIPTION
If the user passes `output_path` as an s3_path (`s3://<bucket-name>/path/to/dir`), the results are stored in the corresponding path of the given bucket. If `aws_key` and `aws_secret` are provided, they will be used to authenticate the s3 requests.

✅ Ran with aws credentials and a private s3 bucket, and verified that the output file was uploaded.

Resolve https://github.com/sdv-dev/SDGym/issues/80
