### PR TITLE
Allow collect to read from and write to s3

### DIFF
--- a/sdgym/__main__.py
+++ b/sdgym/__main__.py
@@ -128,7 +128,7 @@ def _list_available(args):
 
 
 def _collect(args):
-    sdgym.collect.collect_results(args.input_path, args.output_file)
+    sdgym.collect.collect_results(args.input_path, args.output_file, args.aws_key, args.aws_secret)
 
 
 def _get_parser():
@@ -230,6 +230,10 @@ def _get_parser():
                          help='Path within which to look for sdgym results.')
     collect.add_argument('-o', '--output-file', type=str,
                          help='Output file containing the collected results.')
+    collect.add_argument('-ak', '--aws-key', type=str, required=False,
+                         help='Aws access key ID to use when reading datasets.')
+    collect.add_argument('-as', '--aws-secret', type=str, required=False,
+                         help='Aws secret access key to use when reading datasets.')
 
     return parser
 

--- a/sdgym/collect.py
+++ b/sdgym/collect.py
@@ -1,10 +1,7 @@
-import pathlib
-
-import pandas as pd
-import tqdm
+from sdgym.s3 import read_csv_from_path, write_csv
 
 
-def collect_results(input_path, output_file):
+def collect_results(input_path, output_file=None, aws_key=None, aws_secret=None):
     """Collect the results in the given input directory, and
     write all the results into one csv file.
 
@@ -16,20 +13,23 @@ def collect_results(input_path, output_file):
             If ``output_file`` is provided, the consolidated
             results will be written there. Otherwise, they
             will be written to ``input_path``/results.csv.
+        aws_key (str):
+            If an ``aws_key`` is provided, the given access
+            key id will be used to read from and/or write to
+            any s3 paths.
+        aws_secret (str):
+            If an ``aws_secret`` is provided, the given secret
+            access key will be used to read from and/or write to
+            any s3 paths.
     """
     print(f'Reading results from {input_path}')
-    run_path = pathlib.Path(input_path)
-
-    scores = []
-    for path in tqdm.tqdm(list(run_path.glob('**/*.csv'))):
-        scores.append(pd.read_csv(path))
-
-    scores = pd.concat(scores).drop_duplicates()
+    scores = read_csv_from_path(input_path, aws_key, aws_secret)
+    scores = scores.drop_duplicates()
 
     if output_file:
         output = output_file
     else:
-        output = run_path / 'results.csv'
+        output = f'{input_path}/results.csv'
 
     print(f'Storing results at {output}')
-    scores.to_csv(output, index=False)
+    write_csv(scores, output, aws_key, aws_secret)

--- a/sdgym/s3.py
+++ b/sdgym/s3.py
@@ -1,5 +1,10 @@
+import io
+import pathlib
+
 import boto3
 import botocore
+import pandas as pd
+import tqdm
 
 S3_PREFIX = 's3://'
 
@@ -144,3 +149,97 @@ def write_csv(data, path, aws_key, aws_secret):
     """
     contents = data.to_csv(index=False).encode('utf-8')
     write_file(contents, path, aws_key, aws_secret)
+
+
+def read_file(path, aws_key, aws_secret):
+    """Read file from path.
+
+    The path can either be a local path or an s3 directory.
+
+    Args:
+        path (str):
+            The path to the file.
+        aws_key (str):
+            The access key id that will be used to communicate with s3,
+            if provided.
+        aws_secret (str):
+            The secret access key that will be used to communicate with
+            s3, if provided.
+
+    Returns:
+        bytes:
+            The content of the file in bytes.
+    """
+    if is_s3_path(path):
+        s3 = get_s3_client(aws_key, aws_secret)
+        bucket_name, key = parse_s3_path(path)
+        obj = s3.get_object(Bucket=bucket_name, Key=key)
+        contents = obj['Body'].read()
+    else:
+        with open(path, 'r') as f:
+            contents = f.read().encode('utf-8')
+
+    return contents
+
+
+def read_csv(path, aws_key, aws_secret):
+    """Read csv file from path.
+
+    The path can either be a local path or an s3 directory.
+
+    Args:
+        path (str):
+            The path to the csv file.
+        aws_key (str):
+            The access key id that will be used to communicate with s3,
+            if provided.
+        aws_secret (str):
+            The secret access key that will be used to communicate with
+            s3, if provided.
+
+    Returns:
+        pandas.DataFrame:
+            A DataFrame containing the contents of the csv file.
+    """
+    contents = read_file(path, aws_key, aws_secret)
+    return pd.read_csv(io.BytesIO(contents))
+
+
+def read_csv_from_path(path, aws_key, aws_secret):
+    """Read all csv content within a path.
+
+    All csv content within a path will be read and returned in a
+    DataFrame. The path can be either local or an s3 directory.
+
+    args:
+        path (str):
+            The path to read from, which can be either local or an
+            s3 path.
+        aws_key (str):
+            The access key id that will be used to communicate with s3,
+            if provided.
+        aws_secret (str):
+            The secret access key that will be used to communicate with
+            s3, if provided.
+
+    Returns:
+        pandas.DataFrame:
+            A DataFrame of all the csv contents in the path.
+    """
+    csv_contents = []
+    if is_s3_path(path):
+        s3 = get_s3_client(aws_key, aws_secret)
+        bucket_name, key_prefix = parse_s3_path(path)
+        resp = s3.list_objects(Bucket=bucket_name, Prefix=key_prefix)
+        csv_files = [f for f in resp['Contents'] if f['Key'].endswith('.csv')]
+        for csv_file in csv_files:
+            csv_file_key = csv_file['Key']
+            csv_contents.append(
+                read_csv(f's3://{bucket_name}/{csv_file_key}', aws_key, aws_secret))
+
+    else:
+        run_path = pathlib.Path(path)
+        for csv_path in tqdm.tqdm(list(run_path.glob('**/*.csv'))):
+            csv_contents.append(pd.read_csv(csv_path))
+
+    return pd.concat(csv_contents)


### PR DESCRIPTION
Add the option to download the files from S3 and upload the results to S3. If `input_path` is a s3 path, we will read the results from s3 with the provided credentials. If `output_file` is a s3 path, we will upload the results file to s3 with the provided credentials.

✅ Tested with a private s3 bucket.

Resolves #85 