### PR TITLE
Summary command fixes

### DIFF
--- a/sdgym/__main__.py
+++ b/sdgym/__main__.py
@@ -137,8 +137,8 @@ def _collect(args):
 
 
 def _summary(args):
-    sdgym.summary.make_summary_spreadsheet(args.input_path, args.output_file, args.aws_key,
-                                           args.aws_secret)
+    sdgym.summary.make_summary_spreadsheet(args.input_path, output_path=args.output_file,
+                                           aws_key=args.aws_key, aws_secret=args.aws_secret)
 
 
 def _get_parser():

--- a/sdgym/summary.py
+++ b/sdgym/summary.py
@@ -173,7 +173,10 @@ def add_sheet(dfs, name, writer, cell_fmt, index_fmt, header_fmt):
 
         for idx, column in enumerate(df.columns):
             worksheet.write(startrow, idx, column, header_fmt)
-            width = max(len(column), *df[column].astype(str).str.len()) + 1
+            if df.empty:
+                width = len(column) + 1
+            else:
+                width = max(len(column), *df[column].astype(str).str.len()) + 1
             if len(widths) > idx:
                 widths[idx] = max(widths[idx], width)
             else:

--- a/sdgym/summary.py
+++ b/sdgym/summary.py
@@ -177,6 +177,7 @@ def add_sheet(dfs, name, writer, cell_fmt, index_fmt, header_fmt):
                 width = len(column) + 1
             else:
                 width = max(len(column), *df[column].astype(str).str.len()) + 1
+
             if len(widths) > idx:
                 widths[idx] = max(widths[idx], width)
             else:


### PR DESCRIPTION
Two small fixes to the summary command
- The args to `make_summary_command` weren't being passed in the expected order, so the `aws_key` was being passed in as the `baselines` argument.
- The `width` calculation was getting an error `*** TypeError: 'int' object is not iterable` when the dataframe was empty.