### PR TITLE
Bug when using json configuration on multiple multitable

### DIFF
--- a/sdgym/utils.py
+++ b/sdgym/utils.py
@@ -1,5 +1,6 @@
 """Random utils used by SDGym."""
 
+import copy
 import importlib
 import json
 import logging
@@ -187,14 +188,17 @@ def build_synthesizer(synthesizer, synthesizer_dict):
         callable:
             The synthesizer function
     """
+
+    _synthesizer_dict = copy.deepcopy(synthesizer_dict)
+
     def _synthesizer_function(real_data, metadata):
-        metadata_keyword = synthesizer_dict.get('metadata', '$metadata')
-        real_data_keyword = synthesizer_dict.get('real_data', '$real_data')
-        device_keyword = synthesizer_dict.get('device', '$device')
-        device_attribute = synthesizer_dict.get('device_attribute')
+        metadata_keyword = _synthesizer_dict.get('metadata', '$metadata')
+        real_data_keyword = _synthesizer_dict.get('real_data', '$real_data')
+        device_keyword = _synthesizer_dict.get('device', '$device')
+        device_attribute = _synthesizer_dict.get('device_attribute')
         device = select_device()
 
-        multi_table = 'multi-table' in synthesizer_dict['modalities']
+        multi_table = 'multi-table' in _synthesizer_dict['modalities']
         if not multi_table:
             table = metadata.get_tables()[0]
             metadata = metadata.get_table_meta(table)
@@ -206,8 +210,8 @@ def build_synthesizer(synthesizer, synthesizer_dict):
             (device_keyword, device),
         ]
 
-        init_kwargs = _get_kwargs(synthesizer_dict, 'init', replace)
-        fit_kwargs = _get_kwargs(synthesizer_dict, 'fit', replace)
+        init_kwargs = _get_kwargs(_synthesizer_dict, 'init', replace)
+        fit_kwargs = _get_kwargs(_synthesizer_dict, 'fit', replace)
 
         instance = synthesizer(**init_kwargs)
         if device_attribute:

--- a/tests/integration/test_benchmark.py
+++ b/tests/integration/test_benchmark.py
@@ -53,3 +53,27 @@ def test_json_synthesizer():
     )
 
     assert set(output['synthesizer']) == {'synthesizer_name'}
+
+
+def test_json_synthesizer_multi_table():
+    synthesizer = {
+        'name': 'HMA1',
+        'synthesizer': 'sdv.relational.HMA1',
+        'modalities': [
+            'multi-table'
+        ],
+        'init_kwargs': {
+            'metadata': '$metadata'
+        },
+        'fit_kwargs': {
+            'tables': '$real_data'
+        }
+    }
+
+    output = sdgym.run(
+        synthesizers=[json.dumps(synthesizer)],
+        datasets=['university_v1', 'trains_v1'],
+        iterations=1,
+    )
+
+    assert not output.error.any()

--- a/tests/integration/test_benchmark.py
+++ b/tests/integration/test_benchmark.py
@@ -39,11 +39,11 @@ def test_identity_jobs():
 
 def test_json_synthesizer():
     synthesizer = {
-        "name": "synthesizer_name",
-        "synthesizer": "sdgym.synthesizers.ydata.PreprocessedVanillaGAN",
-        "modalities": ["single-table"],
-        "init_kwargs": {"categorical_transformer": "label_encoding"},
-        "fit_kwargs": {"data": "$real_data"}
+        'name': 'synthesizer_name',
+        'synthesizer': 'sdgym.synthesizers.ydata.PreprocessedVanillaGAN',
+        'modalities': ['single-table'],
+        'init_kwargs': {'categorical_transformer': 'label_encoding'},
+        'fit_kwargs': {'data': '$real_data'}
     }
 
     output = sdgym.run(
@@ -52,4 +52,4 @@ def test_json_synthesizer():
         iterations=1,
     )
 
-    assert set(output['synthesizer']) == {"synthesizer_name"}
+    assert set(output['synthesizer']) == {'synthesizer_name'}


### PR DESCRIPTION
* Update `test_benchmark` to follow same string quotes.
* Create a test that produces the error.
* Fix the error by adding a `deepcopy` to the dictionary.

Resolves #115
