### PR TITLE
Fix meta.yaml dependencies

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -24,7 +24,6 @@ requirements:
     - appdirs >=1.1.4,<2
     - boto3 >=1.15.0,<2
     - botocore >=1.20,<2
-    - compress-pickle >=1.2.0,<2
     - humanfriendly >=8.2,<9
     - numpy >=1.18.0,<2
     - pandas >=1.1,<1.1.5
@@ -35,7 +34,7 @@ requirements:
     - sdv >=0.9.0
     - scikit-learn >=0.23,<1
     - tabulate >=0.8.3,<0.9
-    - torch >=1.4,<2
+    - pytorch >=1.4,<2
     - tqdm >=4.14,<5
     - XlsxWriter >=1.2.8,<1.3
   run:
@@ -43,7 +42,6 @@ requirements:
     - appdirs >=1.1.4,<2
     - boto3 >=1.15.0,<2
     - botocore >=1.20,<2
-    - compress-pickle >=1.2.0,<2
     - humanfriendly >=8.2,<9
     - numpy >=1.18.0,<2
     - pandas >=1.1,<1.1.5
@@ -54,7 +52,7 @@ requirements:
     - sdv >=0.9.0
     - scikit-learn >=0.23,<1
     - tabulate >=0.8.3,<0.9
-    - torch >=1.4,<2
+    - pytorch >=1.4,<2
     - tqdm >=4.14,<5
     - XlsxWriter >=1.2.8,<1.3
 


### PR DESCRIPTION
Corrects some dependency issues with the meta.yaml file. Specifically, changes `torch` to `pytorch`, because anaconda's version of `torch` is called `pytorch`, and removes `compress-pickle` because that package is not available through anaconda.