### PR TITLE
Updates and bugfixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM nvidia/cuda:11.0.3-cudnn8-devel-ubuntu18.04
 CMD nvidia-smi
 
-RUN apt-get update && apt-get install -y build-essential && apt-get -y install curl
-RUN apt-get -y install python3.8 python3-distutils && ln -s /usr/bin/python3.8 /usr/bin/python
+RUN apt-get update && apt-get install -y build-essential curl python3.7 python3.7-dev \
+    python3-distutils && ln -s /usr/bin/python3.7 /usr/bin/python
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
     python get-pip.py && ln -s /usr/bin/pip3 /usr/bin/pip
 
@@ -18,8 +18,9 @@ COPY /privbayes/ /SDGym/privbayes
 WORKDIR /SDGym
 
 # Install project
-RUN make install-all compile
-RUN pip install -U numpy==1.20
+RUN pip install ydata-synthetic==0.6.1
+RUN pip install .[gretel] --no-binary pomegranate
+RUN make compile
 ENV PRIVBAYES_BIN /SDGym/privbayes/privBayes.bin
 ENV TF_CPP_MIN_LOG_LEVEL 2
 

--- a/Makefile
+++ b/Makefile
@@ -104,8 +104,13 @@ install-gretel-develop: clean-build clean-compile clean-pyc compile ## install t
 
 .PHONY: install-all
 install-all: clean-build clean-compile clean-pyc compile ## install the package with gretel and ydata
-	pip install 'ydata-synthetic>=0.3.0,<0.4'
+	pip install 'ydata-synthetic==0.6.1'
 	pip install .[gretel]
+
+.PHONY: install-all-develop
+install-all-develop: clean-build clean-compile clean-pyc compile ## install the package with gretel and ydata
+	pip install 'ydata-synthetic==0.6.1'
+	pip install -e .[dev,gretel]
 
 # LINT TARGETS
 

--- a/sdgym/__init__.py
+++ b/sdgym/__init__.py
@@ -10,11 +10,17 @@ __email__ = 'dailabmit@gmail.com'
 __license__ = 'MIT'
 __version__ = '0.5.1.dev0'
 
+import logging
+
 from sdgym import benchmark, synthesizers
 from sdgym.benchmark import run
 from sdgym.collect import collect_results
 from sdgym.datasets import load_dataset
 from sdgym.summary import make_summary_spreadsheet
+
+# Clear the logging wrongfully configured by tensorflow/absl
+list(map(logging.root.removeHandler, logging.root.handlers))
+list(map(logging.root.removeFilter, logging.root.filters))
 
 __all__ = [
     'benchmark',

--- a/sdgym/benchmark.py
+++ b/sdgym/benchmark.py
@@ -338,8 +338,12 @@ def run(synthesizers=None, datasets=None, datasets_path=None, modalities=None, b
     job_args = list()
     for synthesizer, dataset, iteration in job_tuples:
         metadata = load_dataset(dataset, max_columns=max_columns)
-        modalities_ = modalities or synthesizer.get('modalities')
-        if not modalities_ or metadata.modality in modalities_:
+        dataset_modality = metadata.modality
+        if modalities and dataset_modality not in modalities:
+            continue
+
+        synthesizer_modalities = synthesizer.get('modalities')
+        if not synthesizer_modalities or dataset_modality in synthesizer_modalities:
             args = (
                 synthesizer,
                 metadata,

--- a/sdgym/metrics.py
+++ b/sdgym/metrics.py
@@ -12,6 +12,9 @@ class WithKWargs:
     def compute(self, real_data, synthetic_data, metadata):
         return self._metric.compute(real_data, synthetic_data, metadata, **self._kwargs)
 
+    def normalize(self, raw_score):
+        return self._metric.normalize(raw_score)
+
 
 # Metrics to use by default for specific problem types and data
 # modalities if no metrics have been explicitly specified.

--- a/sdgym/s3.py
+++ b/sdgym/s3.py
@@ -107,6 +107,8 @@ def write_file(contents, path, aws_key, aws_secret):
     if path.endswith('gz') or path.endswith('gzip'):
         content_encoding = 'gzip'
         write_mode = 'wb'
+    elif isinstance(contents, bytes):
+        write_mode = 'wb'
 
     if is_s3_path(path):
         s3 = get_s3_client(aws_key, aws_secret)

--- a/sdgym/synthesizers/__init__.py
+++ b/sdgym/synthesizers/__init__.py
@@ -11,7 +11,8 @@ from sdgym.synthesizers.tablegan import TableGAN
 from sdgym.synthesizers.uniform import Uniform
 from sdgym.synthesizers.veegan import VEEGAN
 from sdgym.synthesizers.ydata import (
-    DRAGAN, WGAN_GP, PreprocessedDRAGAN, PreprocessedVanillaGAN, PreprocessedWGAN_GP, VanillaGAN)
+    CRAMERGAN, DRAGAN, WGAN, WGAN_GP, PreprocessedCRAMERGAN, PreprocessedDRAGAN,
+    PreprocessedVanilllaGAN, PreprocessedWGAN, PreprocessedWGAN_GP, VanilllaGAN)
 
 __all__ = (
     'CLBN',
@@ -29,10 +30,14 @@ __all__ = (
     'GaussianCopulaOneHot',
     'Gretel',
     'PreprocessedGretel',
-    'VanillaGAN',
-    'DRAGAN',
+    'VanilllaGAN',
+    'WGAN',
     'WGAN_GP',
-    'PreprocessedDRAGAN',
+    'DRAGAN',
+    'CRAMERGAN',
+    'PreprocessedVanilllaGAN',
+    'PreprocessedWGAN',
     'PreprocessedWGAN_GP',
-    'PreprocessedVanillaGAN',
+    'PreprocessedDRAGAN',
+    'PreprocessedCRAMERGAN',
 )

--- a/sdgym/synthesizers/sdv.py
+++ b/sdgym/synthesizers/sdv.py
@@ -59,16 +59,16 @@ class GaussianCopulaOneHot(SDVTabular):
 
     _MODEL = sdv.tabular.GaussianCopula
     _MODEL_KWARGS = {
-        'categorical_transformer': 'OneHotEncodingTransformer'
+        'categorical_transformer': 'one_hot_encoding'
     }
 
 
 class CUDATabular(SDVTabular, abc.ABC):
 
     def _fit_sample(self, data, metadata):
-        LOGGER.info('Fitting %s', self.__class__.__name__)
         model_kwargs = self._MODEL_KWARGS.copy() if self._MODEL_KWARGS else {}
         model_kwargs.setdefault('cuda', select_device())
+        LOGGER.info('Fitting %s with kwargs %s', self.__class__.__name__, model_kwargs)
         model = self._MODEL(table_metadata=metadata, **model_kwargs)
         model.fit(data)
 

--- a/sdgym/synthesizers/ydata.py
+++ b/sdgym/synthesizers/ydata.py
@@ -1,100 +1,136 @@
 import abc
 
+from sdgym.errors import UnsupportedDataset
 from sdgym.synthesizers.base import SingleTableBaseline
 
 try:
-    import ydata_synthetic.synthesizers.regular as ydata
+    import ydata_synthetic as ydata
+    from ydata_synthetic.synthesizers import regular
+    from ydata_synthetic.synthesizers import ModelParameters, TrainParameters
 except ImportError:
     ydata = None
 
 
 class YData(SingleTableBaseline, abc.ABC):
 
+    SYNTHESIZER_CLASS = None
+    DEFAULT_NOISE_DIM = 128
+    DEFAULT_DIM = 128
+    DEFAULT_BATCH_SIZE = 500
+    DEFAULT_LOG_STEP = 100
+    DEFAULT_EPOCHS = 301
+    DEFAULT_LEARNING_RATE = 1e-5
+    DEFAULT_BETA_1 = 0.5
+    DEFAULT_BETA_2 = 0.9
+    EXTRA_KWARGS = {}
+
+    def __init__(self, noise_dim=None, dim=None, batch_size=None, log_step=None,
+                 epochs=None, learning_rate=None, beta_1=None, beta_2=None, extra_kwargs=None):
+        self.noise_dim = noise_dim or self.DEFAULT_NOISE_DIM
+        self.dim = dim or self.DEFAULT_DIM
+        self.batch_size = batch_size or self.DEFAULT_BATCH_SIZE
+        self.log_step = log_step or self.DEFAULT_LOG_STEP
+        self.epochs = epochs or self.DEFAULT_EPOCHS
+        self.learning_rate = learning_rate or self.DEFAULT_LEARNING_RATE
+        self.beta_1 = beta_1 or self.DEFAULT_BETA_1
+        self.beta_2 = beta_2 or self.DEFAULT_BETA_2
+        if extra_kwargs:
+            self.extra_kwargs = extra_kwargs
+        elif self.EXTRA_KWARGS:
+            self.extra_kwargs = self.EXTRA_KWARGS.copy()
+        else:
+            self.extra_kwargs = {}
+
+    def _fit_synthesizer(self, data, numericals, categoricals):
+        model_args = ModelParameters(
+            batch_size=self.batch_size,
+            lr=self.learning_rate,
+            betas=(self.beta_1, self.beta_2),
+            noise_dim=self.noise_dim,
+            layers_dim=self.dim
+        )
+        train_args = TrainParameters(epochs=self.epochs, sample_interval=self.log_step)
+
+        synthesizer = getattr(regular, self.SYNTHESIZER_CLASS)(model_args, **self.extra_kwargs)
+        synthesizer.train(data, train_args, numericals, categoricals)
+
+        return synthesizer
+
     def _fit_sample(self, real_data, table_metadata):
         if ydata is None:
             raise ImportError('Please install ydata using `make install-ydata`.')
 
         columns = real_data.columns
-        synthesizer = self._build_ydata_synthesizer(real_data)
+        if self.CONVERT_TO_NUMERIC:
+            numericals = list(columns)
+            categoricals = []
+        else:
+            numericals = []
+            categoricals = []
+            for field_name, field_meta in table_metadata['fields'].items():
+                field_type = field_meta['type']
+                if field_type in ('categorical', 'boolean'):
+                    categoricals.append(field_name)
+                elif field_type == 'numerical':
+                    numericals.append(field_name)
+                else:
+                    raise UnsupportedDataset(f'Unsupported field type: {field_type}')
+
+        synthesizer = self._fit_synthesizer(real_data, numericals, categoricals)
         synthetic_data = synthesizer.sample(len(real_data))
         synthetic_data.columns = columns
 
         return synthetic_data
 
 
-class VanillaGAN(YData):
+class VanilllaGAN(YData):
 
-    def __init__(self, noise_dim=32, dim=128, batch_size=128, log_step=100,
-                 epochs=201, learning_rate=5e-4, beta_1=0.5, beta_2=0.9):
-        self.noise_dim = noise_dim
-        self.dim = dim
-        self.batch_size = batch_size
-        self.log_step = log_step
-        self.epochs = epochs
-        self.learning_rate = learning_rate
-        self.beta_1 = beta_1
-        self.beta_2 = beta_2
+    SYNTHESIZER_CLASS = 'VanilllaGAN'
+    LEARNING_RATE = 5e-4
+    EPOCHS = 201
 
-    def _build_ydata_synthesizer(self, data):
-        model_args = [self.batch_size, self.learning_rate, self.beta_1, self.beta_2,
-                      self.noise_dim, data.shape[1], self.dim]
-        train_args = ['', self.epochs, self.log_step]
 
-        synthesizer = ydata.VanilllaGAN(model_args)
-        synthesizer.train(data, train_args)
+class WGAN(YData):
 
-        return synthesizer
+    SYNTHESIZER_CLASS = 'WGAN'
+    DEFAULT_LEARNING_RATE = 5e-4
+    EXTRA_KWARGS = {
+        'n_critic': 2
+    }
 
 
 class WGAN_GP(YData):
 
-    def __init__(self, noise_dim=32, dim=128, batch_size=128, log_step=100,
-                 epochs=201, learning_rate=5e-4, beta_1=0.5, beta_2=0.9):
-        self.noise_dim = noise_dim
-        self.dim = dim
-        self.batch_size = batch_size
-        self.log_step = log_step
-        self.epochs = epochs
-        self.learning_rate = learning_rate
-        self.beta_1 = beta_1
-        self.beta_2 = beta_2
-
-    def _build_ydata_synthesizer(self, data):
-        model_args = [self.batch_size, self.learning_rate, self.beta_1, self.beta_2,
-                      self.noise_dim, data.shape[1], self.dim]
-        train_args = ['', self.epochs, self.log_step]
-
-        synthesizer = ydata.WGAN_GP(model_args, n_critic=2)
-        synthesizer.train(data, train_args)
-
-        return synthesizer
+    SYNTHESIZER_CLASS = 'WGAN_GP'
+    DEFAULT_LEARNING_RATE = [5e-4, 3e-3]
+    EXTRA_KWARGS = {
+        'n_critic': 2
+    }
 
 
 class DRAGAN(YData):
 
-    def __init__(self, noise_dim=128, dim=128, batch_size=500, log_step=100,
-                 epochs=201, learning_rate=1e-5, beta_1=0.5, beta_2=0.9):
-        self.noise_dim = noise_dim
-        self.dim = dim
-        self.batch_size = batch_size
-        self.log_step = log_step
-        self.epochs = epochs
-        self.learning_rate = learning_rate
-        self.beta_1 = beta_1
-        self.beta_2 = beta_2
-
-    def _build_ydata_synthesizer(self, data):
-        gan_args = [self.batch_size, self.learning_rate, self.beta_1, self.beta_2,
-                    self.noise_dim, data.shape[1], self.dim]
-        train_args = ['', self.epochs, self.log_step]
-
-        synthesizer = ydata.DRAGAN(gan_args, n_discriminator=3)
-        synthesizer.train(data, train_args)
-
-        return synthesizer
+    SYNTHESIZER_CLASS = 'DRAGAN'
+    EXTRA_KWARGS = {
+        'n_discriminator': 3
+    }
 
 
-class PreprocessedDRAGAN(DRAGAN):
+class CRAMERGAN(YData):
+
+    SYNTHESIZER_CLASS = 'CRAMERGAN'
+    DEFAULT_LEARNING_RATE = 5e-4
+    EXTRA_KWARGS = {
+        'gradient_penalty_weight': 10
+    }
+
+
+class PreprocessedVanilllaGAN(VanilllaGAN):
+
+    CONVERT_TO_NUMERIC = True
+
+
+class PreprocessedWGAN(WGAN):
 
     CONVERT_TO_NUMERIC = True
 
@@ -104,6 +140,11 @@ class PreprocessedWGAN_GP(WGAN_GP):
     CONVERT_TO_NUMERIC = True
 
 
-class PreprocessedVanillaGAN(VanillaGAN):
+class PreprocessedDRAGAN(DRAGAN):
+
+    CONVERT_TO_NUMERIC = True
+
+
+class PreprocessedCRAMERGAN(CRAMERGAN):
 
     CONVERT_TO_NUMERIC = True

--- a/sdgym/utils.py
+++ b/sdgym/utils.py
@@ -110,16 +110,17 @@ def _get_synthesizer(synthesizer, name=None):
     }
 
 
-def get_synthesizers(synthesizers):
+def get_synthesizers(synthesizers=None):
     """Get the dict of synthesizers from the input value.
 
     If the input is a synthesizer or an iterable of synthesizers, get their names
-    and put them on a dict.
+    and put them on a dict. If None is given, get all the available synthesizers.
 
     Args:
-        synthesizers (function, class, list, tuple or dict):
+        synthesizers (function, class, list, tuple, dict or None):
             A synthesizer (function or method or class) or an iterable of synthesizers
             or a dict containing synthesizer names as keys and synthesizers as values.
+            If no synthesizers are given, all the available ones are returned.
 
     Returns:
         dict[str, function]:
@@ -131,6 +132,9 @@ def get_synthesizers(synthesizers):
     """
     if callable(synthesizers):
         return [_get_synthesizer(synthesizers)]
+
+    if not synthesizers:
+        synthesizers = Baseline.get_baselines()
 
     if isinstance(synthesizers, (list, tuple)):
         return [

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ install_requires = [
     "numpy>=1.20.0,<2;python_version>='3.7'",
     'pandas>=1.1.3,<2',
     "pomegranate>=0.13.4,<0.14.2;python_version<'3.7'",
-    "pomegranate>=0.14.1,<0.15;python_version>='3.7'",
+    "pomegranate>=0.14.1,<0.14.7;python_version>='3.7'",
     'psutil>=5.7,<6',
     'scikit-learn>=0.24,<2',
     'scipy>=1.5.4,<2',

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ dask_requires = [
 
 ydata_requires = [
     # preferably install using make install-ydata
-    'ydata-synthetic>=0.3.0,<0.4',
+    'ydata-synthetic==0.6.1',
 ]
 
 gretel_requires = [

--- a/setup.py
+++ b/setup.py
@@ -47,8 +47,7 @@ ydata_requires = [
 ]
 
 gretel_requires = [
-    'gretel-synthetics>=0.15.4,<0.16',
-    'tensorflow==2.4.0rc1',
+    'gretel-synthetics==0.17',
     'wheel~=0.35',
 ]
 


### PR DESCRIPTION
Fix a bunch of errors that accumulated over time and also update a few dependencies.

List of changes are:
- Adapt LegacySingleTableBaseline to the latest RDT api by transforming only when categoricals are present in the data and also produce the right column names when sampling.
- Fix an argument value in GaussianCopulaOneHot which made it crash: `OneHotEncodingTransformer` -> `one_hot_encoding`
- Update to the latest gretel-synthetics version
- Update to the latest ydata-synthetic version, fix a few bugs (like using the wrong class name `VanillaGAN` -> `VanilllaGAN`) and add new models
- Adapt the Dockerfile to latest dependency versions and installation commants
- Fix logging problems created by the latest tensorflow and absl-py releases
- Default to running on all the synthesizers if none are given
- Fix error when writting an xlsx file to a local path