### PR TITLE
Import TVAE model

### DIFF
--- a/sdgym/synthesizers/__init__.py
+++ b/sdgym/synthesizers/__init__.py
@@ -5,7 +5,7 @@ from sdgym.synthesizers.independent import Independent
 from sdgym.synthesizers.medgan import MedGAN
 from sdgym.synthesizers.privbn import PrivBN
 from sdgym.synthesizers.sdv import (
-    CTGAN, CopulaGAN, GaussianCopulaCategorical, GaussianCopulaCategoricalFuzzy,
+    CTGAN, TVAE, CopulaGAN, GaussianCopulaCategorical, GaussianCopulaCategoricalFuzzy,
     GaussianCopulaOneHot)
 from sdgym.synthesizers.tablegan import TableGAN
 from sdgym.synthesizers.uniform import Uniform
@@ -22,6 +22,7 @@ __all__ = (
     'PrivBN',
     'TableGAN',
     'CTGAN',
+    'TVAE',
     'Uniform',
     'VEEGAN',
     'CopulaGAN',

--- a/sdgym/synthesizers/__init__.py
+++ b/sdgym/synthesizers/__init__.py
@@ -6,7 +6,7 @@ from sdgym.synthesizers.medgan import MedGAN
 from sdgym.synthesizers.privbn import PrivBN
 from sdgym.synthesizers.sdv import (
     CTGAN, TVAE, CopulaGAN, GaussianCopulaCategorical, GaussianCopulaCategoricalFuzzy,
-    GaussianCopulaOneHot)
+    GaussianCopulaOneHot, HMA1, PAR)
 from sdgym.synthesizers.tablegan import TableGAN
 from sdgym.synthesizers.uniform import Uniform
 from sdgym.synthesizers.veegan import VEEGAN
@@ -29,6 +29,8 @@ __all__ = (
     'GaussianCopulaCategorical',
     'GaussianCopulaCategoricalFuzzy',
     'GaussianCopulaOneHot',
+    'HMA1',
+    'PAR',
     'Gretel',
     'PreprocessedGretel',
     'VanilllaGAN',


### PR DESCRIPTION
TVAE model is not imported alongside the remaining synthesizers. This change fixes that. It imports TVAE model from synthesizers.sdv and also include it to __all__.