### PR TITLE
Correctly sort imported models

### DIFF
--- a/sdgym/synthesizers/__init__.py
+++ b/sdgym/synthesizers/__init__.py
@@ -5,8 +5,8 @@ from sdgym.synthesizers.independent import Independent
 from sdgym.synthesizers.medgan import MedGAN
 from sdgym.synthesizers.privbn import PrivBN
 from sdgym.synthesizers.sdv import (
-    CTGAN, TVAE, CopulaGAN, GaussianCopulaCategorical, GaussianCopulaCategoricalFuzzy,
-    GaussianCopulaOneHot, HMA1, PAR)
+    CTGAN, HMA1, PAR, TVAE, CopulaGAN, GaussianCopulaCategorical, GaussianCopulaCategoricalFuzzy,
+    GaussianCopulaOneHot)
 from sdgym.synthesizers.tablegan import TableGAN
 from sdgym.synthesizers.uniform import Uniform
 from sdgym.synthesizers.veegan import VEEGAN

--- a/sdgym/synthesizers/__init__.py
+++ b/sdgym/synthesizers/__init__.py
@@ -5,7 +5,7 @@ from sdgym.synthesizers.independent import Independent
 from sdgym.synthesizers.medgan import MedGAN
 from sdgym.synthesizers.privbn import PrivBN
 from sdgym.synthesizers.sdv import (
-    CTGAN, CopulaGAN, GaussianCopulaCategorical, GaussianCopulaCategoricalFuzzy,
+    CTGAN, TVAE, CopulaGAN, GaussianCopulaCategorical, GaussianCopulaCategoricalFuzzy,
     GaussianCopulaOneHot)
 from sdgym.synthesizers.tablegan import TableGAN
 from sdgym.synthesizers.uniform import Uniform
@@ -22,6 +22,7 @@ __all__ = (
     'PrivBN',
     'TableGAN',
     'CTGAN',
+    'TVAE',
     'Uniform',
     'VEEGAN',
     'CopulaGAN',

--- a/sdgym/synthesizers/__init__.py
+++ b/sdgym/synthesizers/__init__.py
@@ -6,7 +6,7 @@ from sdgym.synthesizers.medgan import MedGAN
 from sdgym.synthesizers.privbn import PrivBN
 from sdgym.synthesizers.sdv import (
     CTGAN, TVAE, CopulaGAN, GaussianCopulaCategorical, GaussianCopulaCategoricalFuzzy,
-    GaussianCopulaOneHot)
+    GaussianCopulaOneHot, HMA1, PAR)
 from sdgym.synthesizers.tablegan import TableGAN
 from sdgym.synthesizers.uniform import Uniform
 from sdgym.synthesizers.veegan import VEEGAN
@@ -29,6 +29,8 @@ __all__ = (
     'GaussianCopulaCategorical',
     'GaussianCopulaCategoricalFuzzy',
     'GaussianCopulaOneHot',
+    'HMA1',
+    'PAR',
     'Gretel',
     'PreprocessedGretel',
     'VanilllaGAN',


### PR DESCRIPTION
We are missing `TVAE`, `HMA1`, and `PAR` models in `sdgym/synthesizers/__init__.py`. #137 fixes this, however, the models were incorrectly sorted, I have fixed that with this change.