### PR TITLE
Add helper methods to `benchmark_single_table` and remove `SYNTHESIZER_MAPPING`

### DIFF
--- a/sdgym/benchmark.py
+++ b/sdgym/benchmark.py
@@ -45,6 +45,81 @@ DEFAULT_METRICS = [('NewRowSynthesis', {'synthetic_sample_size': 1000})]
 N_BYTES_IN_MB = 1000 * 1000
 
 
+def _validate_inputs(output_filepath, detailed_results_folder, synthesizers, custom_synthesizers):
+    if output_filepath and os.path.exists(output_filepath):
+        raise ValueError(
+            f'{output_filepath} already exists. '
+            'Please provide a file that does not already exist.'
+        )
+
+    if detailed_results_folder and os.path.exists(detailed_results_folder):
+        raise ValueError(
+            f'{detailed_results_folder} already exists. '
+            'Please provide a folder that does not already exist.'
+        )
+
+    duplicates = get_duplicates(synthesizers) if synthesizers else {}
+    if custom_synthesizers:
+        duplicates.update(get_duplicates(custom_synthesizers))
+    if len(duplicates) > 0:
+        raise ValueError(
+            'Synthesizers must be unique. Please remove repeated values in the `synthesizers` '
+            'and `custom_synthesizers` parameters.'
+        )
+
+
+def _create_detailed_results_directory(detailed_results_folder):
+    if detailed_results_folder and not is_s3_path(detailed_results_folder):
+        detailed_results_folder = Path(detailed_results_folder)
+        os.makedirs(detailed_results_folder, exist_ok=True)
+
+
+def _generate_job_args_list(limit_dataset_size, sdv_datasets, additional_datasets_folder,
+                            sdmetrics, detailed_results_folder, timeout,
+                            compute_quality_score, synthesizers, custom_synthesizers):
+    max_rows, max_columns = (1000, 10) if limit_dataset_size else (None, None)
+    run_id = os.getenv('RUN_ID') or str(uuid.uuid4())[:10]
+
+    synthesizers = get_synthesizers(synthesizers)
+    if custom_synthesizers:
+        custom_synthesizers = get_synthesizers(custom_synthesizers)
+        synthesizers.extend(custom_synthesizers)
+
+    datasets = []
+    if sdv_datasets is not None:
+        datasets = get_dataset_paths(sdv_datasets, None, None, None, None)
+
+    if additional_datasets_folder:
+        additional_datasets = get_dataset_paths(None, None, additional_datasets_folder, None, None)
+        datasets.extend(additional_datasets)
+
+    job_tuples = list()
+    for dataset in datasets:
+        for synthesizer in synthesizers:
+            job_tuples.append((synthesizer, dataset))
+
+    job_args_list = list()
+    for synthesizer, dataset in job_tuples:
+        data, metadata_content = load_dataset('single_table', dataset, max_columns=max_columns)
+        dataset_name = dataset.name
+        args = (
+            synthesizer,
+            data,
+            metadata_content,
+            sdmetrics,
+            detailed_results_folder,
+            timeout,
+            run_id,
+            max_rows,
+            compute_quality_score,
+            dataset_name,
+            'single_table'
+        )
+        job_args_list.append(args)
+
+    return job_args_list
+
+
 def _synthesize(synthesizer_dict, real_data, metadata):
     synthesizer = synthesizer_dict['synthesizer']
     get_synthesizer = None
@@ -222,44 +297,7 @@ def _score_with_timeout(timeout, synthesizer, metadata, metrics, max_rows=None,
         return output
 
 
-def _run_job(args):
-    # Reset random seed
-    np.random.seed()
-
-    synthesizer, data, metadata, metrics, cache_dir, \
-        timeout, run_id, max_rows, compute_quality_score, dataset_name, modality = args
-
-    name = synthesizer['name']
-    LOGGER.info('Evaluating %s on dataset %s with timeout %ss; %s',
-                name, dataset_name, timeout, used_memory())
-
-    output = {}
-    try:
-        if timeout:
-            output = _score_with_timeout(
-                timeout,
-                synthesizer,
-                metadata,
-                metrics,
-                max_rows=max_rows,
-                compute_quality_score=compute_quality_score,
-                modality=modality,
-                dataset_name=dataset_name
-            )
-        else:
-            output = _score(
-                synthesizer,
-                data,
-                metadata,
-                metrics,
-                max_rows=max_rows,
-                compute_quality_score=compute_quality_score,
-                modality=modality,
-                dataset_name=dataset_name
-            )
-    except Exception as error:
-        output['exception'] = error
-
+def _format_output(output, name, dataset_name, compute_quality_score, cache_dir):
     evaluate_time = None
     if 'scores' in output or 'quality_score_time' in output:
         evaluate_time = output.get('quality_score_time', 0)
@@ -303,6 +341,49 @@ def _run_job(args):
     return scores
 
 
+def _run_job(args):
+    # Reset random seed
+    np.random.seed()
+
+    synthesizer, data, metadata, metrics, cache_dir, \
+        timeout, run_id, max_rows, compute_quality_score, dataset_name, modality = args
+
+    name = synthesizer['name']
+    LOGGER.info('Evaluating %s on dataset %s with timeout %ss; %s',
+                name, dataset_name, timeout, used_memory())
+
+    output = {}
+    try:
+        if timeout:
+            output = _score_with_timeout(
+                timeout,
+                synthesizer,
+                metadata,
+                metrics,
+                max_rows=max_rows,
+                compute_quality_score=compute_quality_score,
+                modality=modality,
+                dataset_name=dataset_name
+            )
+        else:
+            output = _score(
+                synthesizer,
+                data,
+                metadata,
+                metrics,
+                max_rows=max_rows,
+                compute_quality_score=compute_quality_score,
+                modality=modality,
+                dataset_name=dataset_name
+            )
+    except Exception as error:
+        output['exception'] = error
+
+    scores = _format_output(output, name, dataset_name, compute_quality_score, cache_dir)
+
+    return scores
+
+
 def _run_on_dask(jobs, verbose):
     """Run the tasks in parallel using dask."""
     try:
@@ -324,6 +405,39 @@ def _run_on_dask(jobs, verbose):
             pass
 
     return dask.compute(*persisted)
+
+
+def _run_jobs(multi_processing_config, job_args_list, show_progress):
+    workers = 1
+    if multi_processing_config:
+        if multi_processing_config['package_name'] == 'dask':
+            workers = 'dask'
+            scores = _run_on_dask(job_args_list, show_progress)
+        else:
+            num_gpus = get_num_gpus()
+            if num_gpus > 0:
+                workers = num_gpus
+            else:
+                workers = multiprocessing.cpu_count()
+
+    if workers in (0, 1):
+        scores = map(_run_job, job_args_list)
+    elif workers != 'dask':
+        pool = concurrent.futures.ProcessPoolExecutor(workers)
+        scores = pool.map(_run_job, job_args_list)
+
+    if show_progress:
+        scores = tqdm.tqdm(scores, total=len(job_args_list), position=0, leave=True)
+    else:
+        scores = tqdm.tqdm(
+            scores, total=len(job_args_list), file=TqdmLogger(), position=0, leave=True)
+
+    if not scores:
+        raise SDGymError('No valid Dataset/Synthesizer combination given.')
+
+    scores = pd.concat(scores, ignore_index=True)
+
+    return scores
 
 
 def benchmark_single_table(synthesizers=DEFAULT_SYNTHESIZERS, custom_synthesizers=None,
@@ -392,99 +506,15 @@ def benchmark_single_table(synthesizers=DEFAULT_SYNTHESIZERS, custom_synthesizer
         pandas.DataFrame:
             A table containing one row per synthesizer + dataset + metric.
     """
-    if output_filepath and os.path.exists(output_filepath):
-        raise ValueError(
-            f'{output_filepath} already exists. '
-            'Please provide a file that does not already exist.'
-        )
+    _validate_inputs(output_filepath, detailed_results_folder, synthesizers, custom_synthesizers)
 
-    if detailed_results_folder and os.path.exists(detailed_results_folder):
-        raise ValueError(
-            f'{detailed_results_folder} already exists. '
-            'Please provide a folder that does not already exist.'
-        )
+    _create_detailed_results_directory(detailed_results_folder)
 
-    duplicates = get_duplicates(synthesizers) if synthesizers else {}
-    if custom_synthesizers:
-        duplicates.update(get_duplicates(custom_synthesizers))
-    if len(duplicates) > 0:
-        raise ValueError(
-            'Synthesizers must be unique. Please remove repeated values in the `synthesizers` '
-            'and `custom_synthesizers` parameters.'
-        )
+    job_args_list = _generate_job_args_list(
+        limit_dataset_size, sdv_datasets, additional_datasets_folder, sdmetrics,
+        detailed_results_folder, timeout, compute_quality_score, synthesizers, custom_synthesizers)
 
-    if detailed_results_folder and not is_s3_path(detailed_results_folder):
-        detailed_results_folder = Path(detailed_results_folder)
-        os.makedirs(detailed_results_folder, exist_ok=True)
-
-    max_rows, max_columns = (1000, 10) if limit_dataset_size else (None, None)
-
-    run_id = os.getenv('RUN_ID') or str(uuid.uuid4())[:10]
-    synthesizers = get_synthesizers(synthesizers)
-    if custom_synthesizers:
-        custom_synthesizers = get_synthesizers(custom_synthesizers)
-        synthesizers.extend(custom_synthesizers)
-
-    datasets = []
-    if sdv_datasets is not None:
-        datasets = get_dataset_paths(sdv_datasets, None, None, None, None)
-
-    if additional_datasets_folder:
-        additional_datasets = get_dataset_paths(None, None, additional_datasets_folder, None, None)
-        datasets.extend(additional_datasets)
-
-    job_tuples = list()
-    for dataset in datasets:
-        for synthesizer in synthesizers:
-            job_tuples.append((synthesizer, dataset))
-
-    job_args = list()
-    for synthesizer, dataset in job_tuples:
-        data, metadata_content = load_dataset('single_table', dataset, max_columns=max_columns)
-        dataset_name = dataset.name
-        args = (
-            synthesizer,
-            data,
-            metadata_content,
-            sdmetrics,
-            detailed_results_folder,
-            timeout,
-            run_id,
-            max_rows,
-            compute_quality_score,
-            dataset_name,
-            'single_table'
-        )
-        job_args.append(args)
-
-    workers = 1
-    if multi_processing_config:
-        if multi_processing_config['package_name'] == 'dask':
-            workers = 'dask'
-            scores = _run_on_dask(job_args, show_progress)
-        else:
-            num_gpus = get_num_gpus()
-            if num_gpus > 0:
-                workers = num_gpus
-            else:
-                workers = multiprocessing.cpu_count()
-
-    if workers in (0, 1):
-        scores = map(_run_job, job_args)
-    elif workers != 'dask':
-        pool = concurrent.futures.ProcessPoolExecutor(workers)
-        scores = pool.map(_run_job, job_args)
-
-    if show_progress:
-        scores = tqdm.tqdm(scores, total=len(job_args), position=0, leave=True)
-    else:
-        scores = tqdm.tqdm(scores, total=len(job_args), file=TqdmLogger(), position=0, leave=True)
-
-    if not scores:
-        raise SDGymError("No valid Dataset/Synthesizer combination given")
-
-    scores = pd.concat(scores, ignore_index=True)
-
+    scores = _run_jobs(multi_processing_config, job_args_list, show_progress)
     if output_filepath:
         write_csv(scores, output_filepath, None, None)
 

--- a/sdgym/synthesizers/generate.py
+++ b/sdgym/synthesizers/generate.py
@@ -1,24 +1,17 @@
 """Synthesizers module."""
 
-from sdv.lite import SingleTablePreset
-from sdv.multi_table.hma import HMASynthesizer
-from sdv.sequential import PARSynthesizer
-from sdv.single_table import (
-    CopulaGANSynthesizer, CTGANSynthesizer, GaussianCopulaSynthesizer, TVAESynthesizer)
-
 from sdgym.synthesizers.base import (
     BaselineSynthesizer, MultiSingleTableBaselineSynthesizer, SingleTableBaselineSynthesizer)
 from sdgym.synthesizers.sdv import FastMLPreset, SDVRelationalSynthesizer, SDVTabularSynthesizer
 
-SYNTHESIZER_MAPPING = {
-    'FastMLPreset': SingleTablePreset,
-    'GaussianCopulaSynthesizer': GaussianCopulaSynthesizer,
-    'CTGANSynthesizer': CTGANSynthesizer,
-    'CopulaGANSynthesizer': CopulaGANSynthesizer,
-    'TVAESynthesizer': TVAESynthesizer,
-    'PARSynthesizer': PARSynthesizer,
-    'HMASynthesizer': HMASynthesizer,
-}
+SYNTHESIZERS = [
+    'FastMLPreset',
+    'GaussianCopulaSynthesizer',
+    'CTGANSynthesizer',
+    'CopulaGANSynthesizer',
+    'TVAESynthesizer',
+    'PARSynthesizer',
+    'HMASynthesizer']
 
 
 def create_sdv_synthesizer_variant(display_name, synthesizer_class, synthesizer_parameters):
@@ -46,10 +39,10 @@ def create_sdv_synthesizer_variant(display_name, synthesizer_class, synthesizer_
         class:
             The synthesizer class.
     """
-    if synthesizer_class not in SYNTHESIZER_MAPPING.keys():
+    if synthesizer_class not in SYNTHESIZERS:
         raise ValueError(
             f'Synthesizer class {synthesizer_class} is not recognized. '
-            f"The supported options are {', '.join(SYNTHESIZER_MAPPING.keys())}"
+            f"The supported options are {SYNTHESIZERS}."
         )
 
     baseclass = SDVTabularSynthesizer
@@ -77,7 +70,7 @@ def create_sdv_synthesizer_variant(display_name, synthesizer_class, synthesizer_
                 the synthesizer.
         """
 
-        _MODEL = SYNTHESIZER_MAPPING.get(synthesizer_class)
+        _MODEL = synthesizer_class
         _MODEL_KWARGS = synthesizer_parameters
 
     NewSynthesizer.__name__ = f'Variant:{display_name}'
@@ -224,7 +217,7 @@ def create_sequential_synthesizer(display_name, get_trained_synthesizer_fn,
         class:
             The synthesizer class.
     """
-    class NewSynthesizer(BaselineSynthesizer):  # Why not inherit from SDVTimeseries?
+    class NewSynthesizer(BaselineSynthesizer):
         """New Synthesizer class.
 
         Args:


### PR DESCRIPTION
As part of #215, this PR:
- Restructures the `benchmark_single_table` function, creating helper methods to make the code easier to understand.
- Removes `SYNTHESIZER_MAPPING`, which used to be useful when the synthesizers in SDV and SDGym had different names. Since they have the same name now, this dictionary is no longer necessary.