### PR TITLE
Remove code support for synthesizers that are not strings/classes

### DIFF
--- a/sdgym/benchmark.py
+++ b/sdgym/benchmark.py
@@ -80,7 +80,6 @@ def _generate_job_args_list(limit_dataset_size, sdv_datasets, additional_dataset
     run_id = os.getenv('RUN_ID') or str(uuid.uuid4())[:10]
 
     # Get list of synthesizer objects
-    synthesizers = DEFAULT_SYNTHESIZERS if synthesizers is None else synthesizers
     custom_synthesizers = [] if custom_synthesizers is None else custom_synthesizers
     synthesizers = get_synthesizers(synthesizers + custom_synthesizers)
 

--- a/sdgym/datasets.py
+++ b/sdgym/datasets.py
@@ -168,7 +168,8 @@ def get_downloaded_datasets(datasets_path=None):
     return pd.DataFrame(datasets)
 
 
-def get_dataset_paths(datasets, datasets_path, bucket, aws_key, aws_secret):
+def get_dataset_paths(datasets=None, datasets_path=None,
+                      bucket=None, aws_key=None, aws_secret=None):
     """Build the full path to datasets and ensure they exist."""
     bucket = bucket or BUCKET
     is_remote = bucket.startswith(S3_PREFIX)

--- a/sdgym/utils.py
+++ b/sdgym/utils.py
@@ -1,14 +1,10 @@
 """Random utils used by SDGym."""
 
-import copy
-import importlib
-import json
 import logging
 import os
 import subprocess
 import sys
 import traceback
-import types
 
 import humanfriendly
 import numpy as np
@@ -27,22 +23,6 @@ def used_memory():
     return humanfriendly.format_size(process.memory_info().rss)
 
 
-def import_object(object_name):
-    """Import an object from its Fully Qualified Name."""
-    if isinstance(object_name, str):
-        parent_name, attribute = object_name.rsplit('.', 1)
-        try:
-            parent = importlib.import_module(parent_name)
-        except ImportError:
-            grand_parent_name, parent_name = parent_name.rsplit('.', 1)
-            grand_parent = importlib.import_module(grand_parent_name)
-            parent = getattr(grand_parent, parent_name)
-
-        return getattr(parent, attribute)
-
-    return object_name
-
-
 def format_exception():
     exception = traceback.format_exc()
     exc_type, exc_value, _ = sys.exc_info()
@@ -50,180 +30,41 @@ def format_exception():
     return exception, error
 
 
-def _get_synthesizer_name(synthesizer):
-    """Get the name of the synthesizer function or class.
-
-    If the given synthesizer is a function, return its name.
-    If it is a method, return the name of the class to which
-    the method belongs.
+def get_synthesizers(synthesizers):
+    """Get the dict of synthesizer name and object for each synthesizer.
 
     Args:
-        synthesizer (function or method):
-            The synthesizer function or method.
-
-    Returns:
-        str:
-            Name of the function or the class to which the method belongs.
-    """
-    if isinstance(synthesizer, types.MethodType):
-        synthesizer_name = synthesizer.__self__.__class__.__name__
-    else:
-        synthesizer_name = getattr(synthesizer, '__name__', 'undefined')
-
-    return synthesizer_name
-
-
-def _get_synthesizer(synthesizer, name=None):
-    if isinstance(synthesizer, dict):
-        return synthesizer
-
-    if isinstance(synthesizer, str):
-        if synthesizer.endswith('.json'):
-            LOGGER.info('Trying to load synthesizer from a JSON file.')
-            with open(synthesizer, 'r') as json_file:
-                return json.load(json_file)
-
-        baselines = BaselineSynthesizer.get_subclasses(include_parents=True)
-        if synthesizer in baselines:
-            LOGGER.info('Trying to import synthesizer by name.')
-            synthesizer = baselines[synthesizer]
-
-        else:
-            try:
-                LOGGER.info('Trying to load synthesizer from JSON string.')
-                return json.loads(synthesizer)
-
-            except Exception:
-                try:
-                    LOGGER.info('Trying to import synthesizer from fully qualified name.')
-                    synthesizer = import_object(synthesizer)
-
-                except Exception:
-                    raise SDGymError(f'Unknown synthesizer {synthesizer}') from None
-
-    if not name:
-        name = _get_synthesizer_name(synthesizer)
-
-    return {
-        'name': name,
-        'synthesizer': synthesizer,
-    }
-
-
-def get_synthesizers(synthesizers=None):
-    """Get the dict of synthesizers from the input value.
-
-    If the input is a synthesizer or an iterable of synthesizers, get their names
-    and put them on a dict. If None is given, get all the available synthesizers.
-
-    Args:
-        synthesizers (function, class, list, tuple, dict or None):
-            A synthesizer (function or method or class) or an iterable of synthesizers
-            or a dict containing synthesizer names as keys and synthesizers as values.
-            If no synthesizers are given, all the available ones are returned.
+        synthesizers (list):
+            An iterable of synthesizer classes and strings.
 
     Returns:
         dict[str, function]:
-            dict containing synthesizer names as keys and function as values.
+            Dict with the synthesizer name and object.
 
     Raises:
         TypeError:
-            if neither a synthesizer or an iterable or a dict is passed.
+            If neither a list is not passed.
     """
-    if callable(synthesizers) or isinstance(synthesizers, tuple):
-        return [_get_synthesizer(synthesizers)]
+    synthesizers = [] if synthesizers is None else synthesizers
+    if not isinstance(synthesizers, list):
+        raise TypeError('`synthesizers` must be a list.')
 
-    if not synthesizers:
-        synthesizers = BaselineSynthesizer.get_baselines()
+    synthesizers_dicts = []
+    for synthesizer in synthesizers:
+        if isinstance(synthesizer, str):
+            baselines = BaselineSynthesizer.get_subclasses(include_parents=True)
+            if synthesizer in baselines:
+                LOGGER.info('Trying to import synthesizer by name.')
+                synthesizer = baselines[synthesizer]
+            else:
+                raise SDGymError(f'Unknown synthesizer {synthesizer}') from None
 
-    if isinstance(synthesizers, list):
-        return [
-            _get_synthesizer(synthesizer)
-            for synthesizer in synthesizers
-        ]
+        synthesizers_dicts.append({
+            'name': getattr(synthesizer, '__name__', 'undefined'),
+            'synthesizer': synthesizer,
+        })
 
-    if isinstance(synthesizers, dict):
-        return [
-            _get_synthesizer(synthesizer, name)
-            for name, synthesizer in synthesizers.items()
-        ]
-
-    raise TypeError('`synthesizers` can only be a function, a class, a list or a dict')
-
-
-def _get_kwargs(synthesizer_dict, method_name, replace):
-    method_kwargs = synthesizer_dict.get(method_name + '_kwargs', {})
-    for key, value in method_kwargs.items():
-        for replace_keyword, replace_value in replace:
-            if isinstance(value, type(replace_keyword)) and value == replace_keyword:
-                method_kwargs[key] = replace_value
-
-    return method_kwargs
-
-
-def build_synthesizer(synthesizer, synthesizer_dict):
-    """Build a synthesizer function for a dict specification.
-
-    The dict specification may contain any combination of the following entries:
-        * ``modalities``: List of modalities supported by this synthesizer.
-        * ``init``: Dict with the keyword arguments to pass to the ``__init__`` method. The
-          arguments should include the metadata, real data or device arguments when
-          required, encoded as the corresponding keywords.
-        * ``fit``: Dict with the keyword arguments to pass to the ``fit`` method. The
-          arguments should include the metadata, real data or device arguments when
-          required, encoded as the corresponding keywords.
-        * ``modalities``: List of modalities supported by this synthesizer.
-        * ``metadata``: Keyword that should be replaced by the ``metadata`` object
-          when building the ``__init__`` and ``fit`` arguments. Defaults to ``$metadata``.
-        * ``real_data``: Keyword that should be replaced by the ``real_data`` object
-          when building the ``__init__`` and ``fit`` arguments. Defaults to ``$real_data``.
-        * ``device``: Keyword that should be replaced by the CUDA device to use
-          when building the ``__init__`` and ``fit`` arguments. Defaults to ``$device``.
-        * ``device_attr``: boolean indicating whether the CUDA device must be set
-          as an attribute instead of passing it as an argument. Defaults to ``False``.
-
-    Args:
-        synthesizer (class):
-            The class to be used in the synthesizer function.
-        synthesizer_dict (dict):
-            Dictionary with the specification of how to use the synthesizer.
-
-    Returns:
-        callable:
-            The synthesizer function
-    """
-
-    _synthesizer_dict = copy.deepcopy(synthesizer_dict)
-
-    def _synthesizer_fit_function(real_data, metadata):
-        metadata_keyword = _synthesizer_dict.get('metadata', '$metadata')
-        real_data_keyword = _synthesizer_dict.get('real_data', '$real_data')
-        device_keyword = _synthesizer_dict.get('device', '$device')
-        device_attribute = _synthesizer_dict.get('device_attribute')
-        device = select_device()
-
-        replace = [
-            (metadata_keyword, metadata),
-            (real_data_keyword, real_data),
-            (device_keyword, device),
-        ]
-
-        init_kwargs = _get_kwargs(_synthesizer_dict, 'init', replace)
-        fit_kwargs = _get_kwargs(_synthesizer_dict, 'fit', replace)
-
-        instance = synthesizer(**init_kwargs)
-        if device_attribute:
-            setattr(instance, device_attribute, device)
-
-        instance.fit(**fit_kwargs)
-        return instance
-
-    def _synthesizer_sample_function(instance, n_samples=None):
-        sampled = instance.sample()
-
-        return sampled
-
-    return _synthesizer_fit_function, _synthesizer_sample_function
+    return synthesizers_dicts
 
 
 def get_size_of(obj, obj_ids=None):


### PR DESCRIPTION
Remove support for synthesizers to be passed as methods/functions/tuples/dictionaries, as well as some minor refactoring of the code.

NOTE: this is an internal change. The refactoring only removes code artifacts, and shouldn't affect the user facing API.