### PR TITLE
Add ability to run on an ec2 instance

### DIFF
--- a/sdgym/benchmark.py
+++ b/sdgym/benchmark.py
@@ -606,7 +606,7 @@ def benchmark_single_table(synthesizers=DEFAULT_SYNTHESIZERS, custom_synthesizer
         output_filepath (str or ``None``):
             A file path for where to write the output as a csv file. If ``None``, no output
             is written. If run_on_ec2 flag output_filepath needs to be defined and
-            the filepath should be structured as: {s3_bucket_name}/{path_to_file} 
+            the filepath should be structured as: {s3_bucket_name}/{path_to_file}
             Please make sure the path exists and permissions are given.
         detailed_results_folder (str or ``None``):
             The folder for where to store the intermediary results. If ``None``, do not store

--- a/sdgym/benchmark.py
+++ b/sdgym/benchmark.py
@@ -625,7 +625,7 @@ def benchmark_single_table(synthesizers=DEFAULT_SYNTHESIZERS, custom_synthesizer
             A table containing one row per synthesizer + dataset + metric.
     """
     if run_on_ec2:
-        LOGGER.info("This will create an instance for the current AWS user's account.")
+        print("This will create an instance for the current AWS user's account.") # noqa
         if output_filepath is not None:
             script_content = _create_sdgym_script(dict(locals()), output_filepath)
             _create_instance_on_ec2(script_content)

--- a/sdgym/benchmark.py
+++ b/sdgym/benchmark.py
@@ -502,6 +502,7 @@ def _create_instance_on_ec2(script_content):
     ec2_client = boto3.client('ec2')
     session = boto3.session.Session()
     credentials = session.get_credentials()
+    print(f'This instance is being created in region: {session.region_name}') # noqa
 
     # User data script to install the library
     user_data_script = f"""#!/bin/bash
@@ -557,7 +558,7 @@ def _create_instance_on_ec2(script_content):
     instance_id = response['Instances'][0]['InstanceId']
     waiter = ec2_client.get_waiter('instance_status_ok')
     waiter.wait(InstanceIds=[instance_id])
-    LOGGER.info(f'Job kicked off for SDGym on {instance_id}')
+    print(f'Job kicked off for SDGym on {instance_id}') # noqa
 
 
 def benchmark_single_table(synthesizers=DEFAULT_SYNTHESIZERS, custom_synthesizers=None,

--- a/sdgym/cli/__main__.py
+++ b/sdgym/cli/__main__.py
@@ -247,6 +247,11 @@ def _get_parser():
         help='Print a progress bar using tqdm.'
     )
     run.add_argument(
+        'run_on_ec2',
+        action='store_true',
+        help='Run job on created ec2 instance with environment aws variables'
+    )
+    run.add_argument(
         '-t',
         '--timeout',
         type=int,

--- a/tests/unit/test_benchmark.py
+++ b/tests/unit/test_benchmark.py
@@ -84,6 +84,7 @@ def test_benchmark_single_table_with_timeout(mock_multiprocessing, mock__score):
     })
     pd.testing.assert_frame_equal(scores, expected_scores)
 
+
 @patch('sdgym.benchmark.boto3.session.Session')
 @patch('sdgym.benchmark._create_instance_on_ec2')
 def test_run_ec2_flag(create_ec2_mock, session_mock):
@@ -115,6 +116,7 @@ def test_run_ec2_flag(create_ec2_mock, session_mock):
     # Assert
     create_ec2_mock.assert_called_once()
 
+
 @patch('sdgym.benchmark.boto3.session.Session')
 def test__create_sdgym_script(session_mock):
     session_mock.get_credentials.return_value = MagicMock()
@@ -145,6 +147,6 @@ def test__create_sdgym_script(session_mock):
     assert 'detailed_results_folder=None' in result
     assert 'multi_processing_config=None' in result
     assert "sdmetrics=[('NewRowSynthesis', {'synthetic_sample_size': 1000})]" in result
-    assert "timeout=600" in result
+    assert 'timeout=600' in result
     assert 'compute_quality_score=False' in result
     assert 'import boto3' in result

--- a/tests/unit/test_benchmark.py
+++ b/tests/unit/test_benchmark.py
@@ -4,6 +4,8 @@ import pandas as pd
 import pytest
 
 from sdgym import benchmark_single_table
+from sdgym.benchmark import _create_sdgym_script
+from sdgym.synthesizers import CTGANSynthesizer, GaussianCopulaSynthesizer
 
 
 @patch('sdgym.benchmark.os.path')
@@ -81,3 +83,89 @@ def test_benchmark_single_table_with_timeout(mock_multiprocessing, mock__score):
         'error': {0: 'Synthesizer Timeout'}
     })
     pd.testing.assert_frame_equal(scores, expected_scores)
+
+
+@patch('sdgym.benchmark._create_instance_on_ec2')
+def test_run_ec2_flag(create_ec2_mock):
+    """Test that the benchmarking function updates the progress bar on one line."""
+    # Setup
+    create_ec2_mock.return_value = MagicMock()
+
+    # Run
+    benchmark_single_table(run_on_ec2=True, output_filepath="BucketName/path")
+
+    # Assert
+    create_ec2_mock.assert_called_once()
+
+    # Run
+    with pytest.raises(ValueError, match=r'In order to run on EC2, please provide an S3 folder output.'):
+        benchmark_single_table(run_on_ec2=True)
+
+    # Assert
+    create_ec2_mock.assert_called_once()
+
+    # Run
+    with pytest.raises(ValueError, match=r'''Invalid output_filepath.
+                   The path should be structured as: <s3_bucket_name>/<path_to_file>
+                   Please make sure the path exists and permissions are given.'''):
+        benchmark_single_table(run_on_ec2=True, output_filepath="Wrong_Format")
+
+    # Assert
+    create_ec2_mock.assert_called_once()
+
+
+def test__create_sdgym_script():
+    # Setup
+    test_params = {
+        'synthesizers': [GaussianCopulaSynthesizer, CTGANSynthesizer],
+        'custom_synthesizers': None,
+        'sdv_datasets': ['adult', 'alarm', 'census', 'child', 'expedia_hotel_logs', 'insurance', 'intrusion', 'news', 'covtype'],
+        'additional_datasets_folder': None,
+        'limit_dataset_size': True,
+        'compute_quality_score': False,
+        'sdmetrics': [('NewRowSynthesis', {'synthetic_sample_size': 1000})],
+        'timeout': 600,
+        'output_filepath': 'sdgym-results/address_comments.csv',
+        'detailed_results_folder': None,
+        'show_progress': False,
+        'multi_processing_config': None,
+        'dummy': True
+    }
+
+    result = _create_sdgym_script(test_params, 'Bucket/Filepath')
+
+    expected_script = """import boto3
+from io import StringIO
+import sdgym
+from sdgym.synthesizers.sdv import (CopulaGANSynthesizer, CTGANSynthesizer, FastMLPreset,
+    GaussianCopulaSynthesizer, HMASynthesizer, PARSynthesizer, SDVRelationalSynthesizer,
+    SDVTabularSynthesizer,TVAESynthesizer)
+
+results = sdgym.benchmark_single_table(
+    synthesizers=[GaussianCopulaSynthesizer, CTGANSynthesizer, ], custom_synthesizers=None,
+    sdv_datasets=['adult', 'alarm', 'census', 'child', 'expedia_hotel_logs', 'insurance', 'intrusion', 'news', 'covtype'],
+    additional_datasets_folder=None,
+    limit_dataset_size=True,
+    compute_quality_score=False,
+    sdmetrics=[('NewRowSynthesis', {'synthetic_sample_size': 1000})], timeout=600,
+    detailed_results_folder=None,
+    multi_processing_config=None
+)
+
+# Convert DataFrame to CSV string
+csv_buffer = StringIO()
+results.to_csv(csv_buffer, index=False)
+s3 = boto3.client('s3',
+    aws_access_key_id='AKIAYUU6OYSLCAY62IFP',
+    aws_secret_access_key='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')
+
+
+# Upload CSV to S3
+response = s3.put_object(
+    Bucket='Bucket',
+    Key='Filepath',
+    Body=csv_buffer.getvalue()
+)
+"""
+
+    assert result == expected_script


### PR DESCRIPTION
resolves #265 

Add the field `run_on_ec2` which spins up an EC2 instance with the environment credentials, runs the latest version of sdgym with the same parameters and saves the output to the s3 bucket. Terminates the Ec2 instance once finished with the process to avoid keeping paid resources alive.

Only issue is that custom synthesizers may not work with this command in this PR (as that requires a standardized way to bring in custom imported classes to the EC2 instance as well) 

