### PR TITLE
Add quotes to string params for script generation

### DIFF
--- a/sdgym/benchmark.py
+++ b/sdgym/benchmark.py
@@ -486,6 +486,10 @@ def _create_sdgym_script(params, output_filepath):
     bucket_name, key_name = _parse_s3_path(output_filepath)
     session = boto3.session.Session()
     credentials = session.get_credentials()
+    if params['additional_datasets_folder']:
+        params['additional_datasets_folder'] = "'" + params['additional_datasets_folder'] + "'"
+    if params['detailed_results_folder']:
+        params['detailed_results_folder'] = "'" + params['detailed_results_folder'] + "'"
     synthesizer_string = 'synthesizers=['
     for synthesizer in params['synthesizers']:
         synthesizer_string += synthesizer.__name__ + ', '
@@ -501,11 +505,11 @@ from sdgym.synthesizers.sdv import (CopulaGANSynthesizer, CTGANSynthesizer, Fast
 results = sdgym.benchmark_single_table(
     {synthesizer_string}, custom_synthesizers={params['custom_synthesizers']},
     sdv_datasets={params['sdv_datasets']},
-    additional_datasets_folder='{params['additional_datasets_folder']}',
+    additional_datasets_folder={params['additional_datasets_folder']},
     limit_dataset_size={params['limit_dataset_size']},
     compute_quality_score={params['compute_quality_score']},
     sdmetrics={params['sdmetrics']}, timeout={params['timeout']},
-    detailed_results_folder='{params['detailed_results_folder']}',
+    detailed_results_folder={params['detailed_results_folder']},
     multi_processing_config={params['multi_processing_config']}
 )
 

--- a/sdgym/benchmark.py
+++ b/sdgym/benchmark.py
@@ -659,8 +659,7 @@ def benchmark_single_table(synthesizers=DEFAULT_SYNTHESIZERS, custom_synthesizer
         print("This will create an instance for the current AWS user's account.")  # noqa
         if output_filepath is not None:
             script_content = _create_sdgym_script(dict(locals()), output_filepath)
-            print(script_content)
-            # _create_instance_on_ec2(script_content)
+            _create_instance_on_ec2(script_content)
         else:
             raise ValueError('In order to run on EC2, please provide an S3 folder output.')
         return None

--- a/sdgym/benchmark.py
+++ b/sdgym/benchmark.py
@@ -501,11 +501,11 @@ from sdgym.synthesizers.sdv import (CopulaGANSynthesizer, CTGANSynthesizer, Fast
 results = sdgym.benchmark_single_table(
     {synthesizer_string}, custom_synthesizers={params['custom_synthesizers']},
     sdv_datasets={params['sdv_datasets']},
-    additional_datasets_folder={params['additional_datasets_folder']},
+    additional_datasets_folder='{params['additional_datasets_folder']}',
     limit_dataset_size={params['limit_dataset_size']},
     compute_quality_score={params['compute_quality_score']},
     sdmetrics={params['sdmetrics']}, timeout={params['timeout']},
-    detailed_results_folder={params['detailed_results_folder']},
+    detailed_results_folder='{params['detailed_results_folder']}',
     multi_processing_config={params['multi_processing_config']}
 )
 
@@ -659,7 +659,8 @@ def benchmark_single_table(synthesizers=DEFAULT_SYNTHESIZERS, custom_synthesizer
         print("This will create an instance for the current AWS user's account.")  # noqa
         if output_filepath is not None:
             script_content = _create_sdgym_script(dict(locals()), output_filepath)
-            _create_instance_on_ec2(script_content)
+            print(script_content)
+            # _create_instance_on_ec2(script_content)
         else:
             raise ValueError('In order to run on EC2, please provide an S3 folder output.')
         return None

--- a/tests/unit/test_benchmark.py
+++ b/tests/unit/test_benchmark.py
@@ -209,7 +209,6 @@ def test__create_sdgym_script(session_mock, mock_write_permissions, mock_directo
             'child', 'expedia_hotel_logs',
             'insurance', 'intrusion', 'news', 'covtype'
         ],
-        'additional_datasets_folder': None,
         'limit_dataset_size': True,
         'compute_quality_score': False,
         'sdmetrics': [('NewRowSynthesis', {'synthetic_sample_size': 1000})],

--- a/tests/unit/test_benchmark.py
+++ b/tests/unit/test_benchmark.py
@@ -216,6 +216,7 @@ def test__create_sdgym_script(session_mock, mock_write_permissions, mock_directo
         'timeout': 600,
         'output_filepath': 'sdgym-results/address_comments.csv',
         'detailed_results_folder': None,
+        'additional_datasets_folder': 'Details/',
         'show_progress': False,
         'multi_processing_config': None,
         'dummy': True
@@ -229,6 +230,7 @@ def test__create_sdgym_script(session_mock, mock_write_permissions, mock_directo
     # Assert
     assert 'synthesizers=[GaussianCopulaSynthesizer, CTGANSynthesizer, ]' in result
     assert 'detailed_results_folder=None' in result
+    assert "additional_datasets_folder='Details/'" in result
     assert 'multi_processing_config=None' in result
     assert "sdmetrics=[('NewRowSynthesis', {'synthetic_sample_size': 1000})]" in result
     assert 'timeout=600' in result


### PR DESCRIPTION
For the script to run on the ec2 instance, string params are missing a quotes for it to run properly