### PR TITLE
Use s3 filepath prefix

### DIFF
--- a/sdgym/benchmark.py
+++ b/sdgym/benchmark.py
@@ -468,28 +468,26 @@ def _check_write_permissions(bucket_name):
     return write_permission
 
 
-def _confirm_s3_filepath(s3_path):
-    if not is_s3_path(s3_path):
+def _create_sdgym_script(params, output_filepath):
+    # Confirm the path works
+    if not is_s3_path(output_filepath):
         raise ValueError("""Invalid S3 path format.
                          Expected 's3://<bucket_name>/<path_to_file>'.""")
-    # Split only on the first '/'
-    bucket_name, key_prefix = parse_s3_path(s3_path)
+    bucket_name, key_prefix = parse_s3_path(output_filepath)
     if not _directory_exists(bucket_name, key_prefix):
         raise ValueError(f'Directories in {key_prefix} do not exist')
     if not _check_write_permissions(bucket_name):
         raise ValueError('No write permissions allowed for the bucket.')
 
-    return bucket_name, key_prefix
-
-
-def _create_sdgym_script(params, output_filepath):
-    bucket_name, key_name = _confirm_s3_filepath(output_filepath)
-    session = boto3.session.Session()
-    credentials = session.get_credentials()
+    # Add quotes to parameter strings
     if params['additional_datasets_folder']:
         params['additional_datasets_folder'] = "'" + params['additional_datasets_folder'] + "'"
     if params['detailed_results_folder']:
         params['detailed_results_folder'] = "'" + params['detailed_results_folder'] + "'"
+    if params['output_filepath']:
+        params['output_filepath'] = "'" + params['output_filepath'] + "'"
+
+    # Generate the output script to run on the e2 instance
     synthesizer_string = 'synthesizers=['
     for synthesizer in params['synthesizers']:
         synthesizer_string += synthesizer.__name__ + ', '
@@ -504,28 +502,13 @@ from sdgym.synthesizers.sdv import (CopulaGANSynthesizer, CTGANSynthesizer, Fast
 
 results = sdgym.benchmark_single_table(
     {synthesizer_string}, custom_synthesizers={params['custom_synthesizers']},
-    sdv_datasets={params['sdv_datasets']},
+    sdv_datasets={params['sdv_datasets']}, output_filepath={params['output_filepath']},
     additional_datasets_folder={params['additional_datasets_folder']},
     limit_dataset_size={params['limit_dataset_size']},
     compute_quality_score={params['compute_quality_score']},
     sdmetrics={params['sdmetrics']}, timeout={params['timeout']},
     detailed_results_folder={params['detailed_results_folder']},
     multi_processing_config={params['multi_processing_config']}
-)
-
-# Convert DataFrame to CSV string
-csv_buffer = StringIO()
-results.to_csv(csv_buffer, index=False)
-s3 = boto3.client('s3',
-    aws_access_key_id='{credentials.access_key}',
-    aws_secret_access_key='{credentials.secret_key}')
-
-
-# Upload CSV to S3
-response = s3.put_object(
-    Bucket='{bucket_name}',
-    Key='{key_name}',
-    Body=csv_buffer.getvalue()
 )
 """
 
@@ -542,20 +525,20 @@ def _create_instance_on_ec2(script_content):
     user_data_script = f"""#!/bin/bash
     sudo apt update -y
     sudo apt install python3-pip -y
-    echo "======== Install SDGYM ============"
+    echo "======== Install Dependencies ============"
     sudo pip3 install sdgym
     sudo pip3 install anyio
     pip3 list
+    sudo apt install awscli -y
+    aws configure set aws_access_key_id {credentials.access_key}
+    aws configure set aws_secret_access_key {credentials.secret_key}
+    aws configure set region {session.region_name}
     echo "======== Write Script ==========="
     sudo touch ~/sdgym_script.py
     echo "{script_content}" > ~/sdgym_script.py
     echo "======== Run Script ==========="
     sudo python3 ~/sdgym_script.py
     echo "======== Terminate ==========="
-    sudo apt install awscli -y
-    aws configure set aws_access_key_id {credentials.access_key}
-    aws configure set aws_secret_access_key {credentials.secret_key}
-    aws configure set region {session.region_name}
     INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
     aws ec2 terminate-instances --instance-ids $INSTANCE_ID
     """

--- a/tests/unit/test_benchmark.py
+++ b/tests/unit/test_benchmark.py
@@ -13,7 +13,7 @@ def test_output_file_exists(path_mock):
     """Test the benchmark function when the output path already exists."""
     # Setup
     path_mock.exists.return_value = True
-    output_filepath = 'test_output.csv'
+    output_filepath = 's3://test_output.csv'
 
     # Run and assert
     with pytest.raises(
@@ -156,7 +156,7 @@ def test_run_ec2_flag(
     mock_directory_exists.return_value = True
 
     # Run
-    benchmark_single_table(run_on_ec2=True, output_filepath='BucketName/path')
+    benchmark_single_table(run_on_ec2=True, output_filepath='s3://BucketName/path')
 
     # Assert
     create_ec2_mock.assert_called_once()
@@ -171,7 +171,7 @@ def test_run_ec2_flag(
 
     # Run
     with pytest.raises(ValueError, match=r"""Invalid S3 path format.
-                         Expected '<bucket_name>/<path_to_file>'."""):
+                         Expected 's3://<bucket_name>/<path_to_file>'."""):
         benchmark_single_table(run_on_ec2=True, output_filepath='Wrong_Format')
 
     # Assert
@@ -183,7 +183,7 @@ def test_run_ec2_flag(
     # Run
     with pytest.raises(ValueError,
                        match=r'No write permissions allowed for the bucket.'):
-        benchmark_single_table(run_on_ec2=True, output_filepath='BucketName/path')
+        benchmark_single_table(run_on_ec2=True, output_filepath='s3://BucketName/path')
 
     # Setup for failure in directory exists
     mock_write_permissions.return_value = True
@@ -192,7 +192,7 @@ def test_run_ec2_flag(
     # Run
     with pytest.raises(ValueError,
                        match=r'Directories in mock/path do not exist'):
-        benchmark_single_table(run_on_ec2=True, output_filepath='BucketName/mock/path')
+        benchmark_single_table(run_on_ec2=True, output_filepath='s3://BucketName/mock/path')
 
 
 @patch('sdgym.benchmark._directory_exists')
@@ -213,7 +213,7 @@ def test__create_sdgym_script(session_mock, mock_write_permissions, mock_directo
         'compute_quality_score': False,
         'sdmetrics': [('NewRowSynthesis', {'synthetic_sample_size': 1000})],
         'timeout': 600,
-        'output_filepath': 'sdgym-results/address_comments.csv',
+        'output_filepath': 's3://sdgym-results/address_comments.csv',
         'detailed_results_folder': None,
         'additional_datasets_folder': 'Details/',
         'show_progress': False,
@@ -224,7 +224,7 @@ def test__create_sdgym_script(session_mock, mock_write_permissions, mock_directo
     mock_directory_exists.return_value = True
 
     # Run
-    result = _create_sdgym_script(test_params, 'Bucket/Filepath')
+    result = _create_sdgym_script(test_params, 's3://Bucket/Filepath')
 
     # Assert
     assert 'synthesizers=[GaussianCopulaSynthesizer, CTGANSynthesizer, ]' in result


### PR DESCRIPTION
To be in line with the rest of the s3 paths, force output_filepath to use `s3://` if ec2 is running