### PR TITLE
Allow instantiated synthesizers in benchmark

### DIFF
--- a/sdgym/benchmark.py
+++ b/sdgym/benchmark.py
@@ -148,11 +148,16 @@ def _generate_job_args_list(
 
 def _synthesize(synthesizer_dict, real_data, metadata):
     synthesizer = synthesizer_dict['synthesizer']
-    assert issubclass(synthesizer, BaselineSynthesizer), '`synthesizer` must be a synthesizer class'
+    if isinstance(synthesizer, type):
+        assert issubclass(synthesizer, BaselineSynthesizer), (
+            '`synthesizer` must be a synthesizer class')
+        synthesizer = synthesizer()
+    else:
+        assert issubclass(type(synthesizer), BaselineSynthesizer), (
+            '`synthesizer` must be an instance of a synthesizer class.')
 
-    synthesizer_object = synthesizer()
-    get_synthesizer = synthesizer_object.get_trained_synthesizer
-    sample_from_synthesizer = synthesizer_object.sample_from_synthesizer
+    get_synthesizer = synthesizer.get_trained_synthesizer
+    sample_from_synthesizer = synthesizer.sample_from_synthesizer
     data = real_data.copy()
     num_samples = len(data)
 

--- a/sdgym/benchmark.py
+++ b/sdgym/benchmark.py
@@ -149,12 +149,14 @@ def _generate_job_args_list(
 def _synthesize(synthesizer_dict, real_data, metadata):
     synthesizer = synthesizer_dict['synthesizer']
     if isinstance(synthesizer, type):
-        assert issubclass(synthesizer, BaselineSynthesizer), (
-            '`synthesizer` must be a synthesizer class')
+        assert issubclass(
+            synthesizer, BaselineSynthesizer
+        ), '`synthesizer` must be a synthesizer class'
         synthesizer = synthesizer()
     else:
-        assert issubclass(type(synthesizer), BaselineSynthesizer), (
-            '`synthesizer` must be an instance of a synthesizer class.')
+        assert issubclass(
+            type(synthesizer), BaselineSynthesizer
+        ), '`synthesizer` must be an instance of a synthesizer class.'
 
     get_synthesizer = synthesizer.get_trained_synthesizer
     sample_from_synthesizer = synthesizer.sample_from_synthesizer

--- a/sdgym/utils.py
+++ b/sdgym/utils.py
@@ -60,8 +60,12 @@ def get_synthesizers(synthesizers):
             else:
                 raise SDGymError(f'Unknown synthesizer {synthesizer}') from None
 
+        if isinstance(synthesizer, type) or hasattr(synthesizer, '__name__'):
+            synthesizer_name = getattr(synthesizer, '__name__', 'undefined')
+        else:
+            synthesizer_name = getattr(type(synthesizer), '__name__', 'undefined')
         synthesizers_dicts.append({
-            'name': getattr(synthesizer, '__name__', 'undefined'),
+            'name': synthesizer_name,
             'synthesizer': synthesizer,
         })
 

--- a/tests/integration/test_benchmark.py
+++ b/tests/integration/test_benchmark.py
@@ -445,6 +445,7 @@ def test_benchmark_single_table_custom_synthesizer():
 
 def test_benchmark_single_table_limit_dataset_size():
     """Test it works with ``limit_dataset_size``."""
+
     # Run
     results = benchmark_single_table(
         synthesizers=['GaussianCopulaSynthesizer'], sdv_datasets=['adult'], limit_dataset_size=True
@@ -475,6 +476,7 @@ def test_benchmark_single_table_limit_dataset_size():
 
 def test_benchmark_single_table_instantiated_synthesizer():
     """Test it with instances of synthesizers instead of the class."""
+
     # Setup
     def get_trained_synthesizer(data, metadata):
         metadata_obj = SingleTableMetadata.load_from_dict(metadata)
@@ -496,7 +498,7 @@ def test_benchmark_single_table_instantiated_synthesizer():
     results = benchmark_single_table(
         synthesizers=None,
         custom_synthesizers=[test_synthesizer_instance],
-        sdv_datasets=['fake_companies']
+        sdv_datasets=['fake_companies'],
     )
 
     # Assert


### PR DESCRIPTION
Resolve #335
Instantiated objects can bypass the pickling issue with the base class in certain situations.