### PR TITLE
Fixing minimum tests and dependencies around RealTabFormer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ sdgym = { main = 'sdgym.cli.__main__:main' }
 [project.optional-dependencies]
 dask = ['dask', 'distributed']
 realtabformer = [
-    'realtabformer>=0.2.1',
+    'realtabformer>=0.2.2',
     "torch>=2.0.0;python_version>='3.8' and python_version<'3.12'",
     "torch>=2.2.0;python_version>='3.12'",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,6 @@ sdgym = { main = 'sdgym.cli.__main__:main' }
 dask = ['dask', 'distributed']
 realtabformer = [
     'realtabformer>=0.2.1',
-    'transformers<4.46',
     "accelerate<1.3.0;python_version<'3.10'",
 ]
 test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ dask = ['dask', 'distributed']
 realtabformer = [
     'realtabformer>=0.2.1',
     "accelerate<1.3.0;python_version<'3.10'",
+    'torch>=2.0.0'
 ]
 test = [
     'sdgym[realtabformer]',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,6 @@ sdgym = { main = 'sdgym.cli.__main__:main' }
 dask = ['dask', 'distributed']
 realtabformer = [
     'realtabformer>=0.2.1',
-    "accelerate<1.3.0;python_version<'3.10'",
     'torch>=2.0.0'
 ]
 test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,8 @@ sdgym = { main = 'sdgym.cli.__main__:main' }
 dask = ['dask', 'distributed']
 realtabformer = [
     'realtabformer>=0.2.1',
-    'torch>=2.0.0'
+    "torch>=2.0.0;python_version>='3.8' and python_version<'3.12'",
+    "torch>=2.2.0;python_version>='3.12'",
 ]
 test = [
     'sdgym[realtabformer]',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,11 @@ sdgym = { main = 'sdgym.cli.__main__:main' }
 
 [project.optional-dependencies]
 dask = ['dask', 'distributed']
-realtabformer = ['realtabformer>=0.2.1', 'transformers<4.46']
+realtabformer = [
+    'realtabformer>=0.2.1',
+    'transformers<4.46',
+    "accelerate<1.3.0;python_version<'3.10'",
+]
 test = [
     'sdgym[realtabformer]',
     'pytest>=6.2.5',

--- a/sdgym/synthesizers/realtabformer.py
+++ b/sdgym/synthesizers/realtabformer.py
@@ -23,6 +23,7 @@ class RealTabFormerSynthesizer(BaselineSynthesizer):
     """Custom wrapper for the REaLTabFormer synthesizer to make it work with SDGym."""
 
     LOGGER = logging.getLogger(__name__)
+    _MODEL_KWARGS = None
 
     def _get_trained_synthesizer(self, data, metadata):
         try:
@@ -34,7 +35,8 @@ class RealTabFormerSynthesizer(BaselineSynthesizer):
             ) from exception
 
         with prevent_tqdm_output():
-            model = REaLTabFormer(model_type='tabular')
+            model_kwargs = self._MODEL_KWARGS.copy() if self._MODEL_KWARGS else {}
+            model = REaLTabFormer(model_type='tabular', **model_kwargs)
             model.fit(data, device='cpu')
 
         return model

--- a/tasks.py
+++ b/tasks.py
@@ -97,7 +97,7 @@ def _get_extra_dependencies(pyproject_data):
         list:
             A list of dependency strings (ie. numpy>=x.y.z).
     """
-    optional_dependencies = pyproject_data.get('project', {}).get('optional-dependencies', [])
+    optional_dependencies = pyproject_data.get('project', {}).get('optional-dependencies', {})
     test_dependencies = optional_dependencies.get('test', [])
     extra_dependencies = []
     start_token = 'sdgym['

--- a/tasks.py
+++ b/tasks.py
@@ -30,7 +30,7 @@ def unit(c):
 
 @task
 def integration(c):
-    c.run('python -m pytest --durations=0 ./tests/integration --cov=sdgym --cov-report=xml:./integration_cov.xml')
+    c.run('python -m pytest ./tests/integration --cov=sdgym --cov-report=xml:./integration_cov.xml')
 
 
 @task

--- a/tasks.py
+++ b/tasks.py
@@ -12,7 +12,7 @@ from packaging.requirements import Requirement
 from packaging.version import Version
 
 COMPARISONS = {'>=': operator.ge, '>': operator.gt, '<': operator.lt, '<=': operator.le}
-
+EGG_STRING = '#egg='
 
 if not hasattr(inspect, 'getargspec'):
     inspect.getargspec = inspect.getfullargspec
@@ -53,7 +53,7 @@ def _get_minimum_versions(dependencies, python_version):
     for dependency in dependencies:
         if '@' in dependency:
             name, url = dependency.split(' @ ')
-            min_versions[name] = f'{url}#egg={name}'
+            min_versions[name] = f'{url}{EGG_STRING}{name}'
             continue
 
         req = Requirement(dependency)
@@ -86,13 +86,16 @@ def _get_minimum_versions(dependencies, python_version):
 def _get_extra_dependencies(pyproject_data):
     """Get the dependencies for optional synthesizers.
 
+    This function assumes that all external synthesizers we add will have an optional dependency
+    section defined and that the section will be listed in the '[test]' optional dependency.
+
     Args:
         pyproject_data (dict):
             Dictionary representation of our pyproject.toml file.
 
     Returns:
         list:
-            A list of dependency strings (ie. numpy>=x.y.z)
+            A list of dependency strings (ie. numpy>=x.y.z).
     """
     optional_dependencies = pyproject_data.get('project', {}).get('optional-dependencies', [])
     test_dependencies = optional_dependencies.get('test', [])
@@ -106,6 +109,49 @@ def _get_extra_dependencies(pyproject_data):
     return extra_dependencies
 
 
+def _get_version_from_requirement(requirement):
+    requirement = requirement.strip()
+    equal_index = requirement.find('==')
+    version_number = requirement[equal_index + 2:]
+    return Version(version_number)
+
+
+def _resolve_version_conflicts(dependencies, extra_dependencies):
+    """Pick the highest version of two minimums.
+
+    Args:
+        dependencies (dict):
+            A dictionary mapping dependency names to the version.
+        extra_dependencies (dict):
+            A dictionary mapping the optional dependency names to the version.
+
+    Returns:
+        list:
+            A list of dependency strings (ie. numpy>=x.y.z).
+    """
+    all_dependencies = set(dependencies.keys()).union(set(extra_dependencies.keys()))
+    selected_versions = []
+    for dep in all_dependencies:
+        if dep in dependencies and dep in extra_dependencies:
+            requirement1 = dependencies.get(dep)
+            requirement2 = extra_dependencies.get(dep)
+            if EGG_STRING in requirement1:
+                selected_versions.append(requirement1)
+                continue
+            if EGG_STRING in requirement2:
+                selected_versions.append(requirement2)
+                continue
+
+            version1 = _get_version_from_requirement(requirement1)
+            version2 = _get_version_from_requirement(requirement2)
+            max_version = requirement1 if version1 > version2 else requirement2
+            selected_versions.append(max_version)
+        else:
+            selected_versions.append(dependencies.get(dep, extra_dependencies.get(dep)))
+
+    return selected_versions
+
+
 @task
 def install_minimum(c):
     with open('pyproject.toml', 'rb') as pyproject_file:
@@ -116,9 +162,7 @@ def install_minimum(c):
     python_version = '.'.join(map(str, sys.version_info[:2]))
     minimum_versions = _get_minimum_versions(dependencies, python_version)
     extra_minimum_versions = _get_minimum_versions(extra_synthesizer_dependencies, python_version)
-    minimum_versions.update(extra_minimum_versions)
-    minimum_versions = list(minimum_versions.values())
-
+    minimum_versions = _resolve_version_conflicts(minimum_versions, extra_minimum_versions)
     if minimum_versions:
         install_deps = ' '.join(minimum_versions)
         c.run(f'python -m pip install {install_deps}')
@@ -147,7 +191,7 @@ def fix_lint(c):
 
 
 def remove_readonly(func, path, _):
-    "Clear the readonly bit and reattempt the removal"
+    """Clear the readonly bit and reattempt the removal"""
     os.chmod(path, stat.S_IWRITE)
     func(path)
 

--- a/tasks.py
+++ b/tasks.py
@@ -30,7 +30,7 @@ def unit(c):
 
 @task
 def integration(c):
-    c.run('python -m pytest ./tests/integration --cov=sdgym --cov-report=xml:./integration_cov.xml')
+    c.run('python -m pytest --durations=0 ./tests/integration --cov=sdgym --cov-report=xml:./integration_cov.xml')
 
 
 @task

--- a/tests/integration/synthesizers/test_realtabformer.py
+++ b/tests/integration/synthesizers/test_realtabformer.py
@@ -14,6 +14,7 @@ def test_realtabformer_end_to_end():
         'single_table', 'student_placements', limit_dataset_size=False
     )
     realtabformer_instance = RealTabFormerSynthesizer()
+    realtabformer_instance._MODEL_KWARGS = {'epochs': 10}
 
     # Run
     trained_synthesizer = realtabformer_instance.get_trained_synthesizer(data, metadata_dict)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -111,7 +111,7 @@ def _get_example_pyproject_dict():
                 'test': [
                     'sdgym[realtabformer]',
                     'pytest>=6.2.5',
-                ]
+                ],
             },
             'readme': 'README.md',
             'requires-python': '>=3.8,<3.13',

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,6 +1,6 @@
 """Tests for the ``tasks.py`` file."""
 
-from tasks import _get_minimum_versions
+from tasks import _get_extra_dependencies, _get_minimum_versions, _resolve_version_conflicts
 
 
 def test_get_minimum_versions():
@@ -24,16 +24,182 @@ def test_get_minimum_versions():
     minimum_versions_310 = _get_minimum_versions(dependencies, '3.10')
 
     # Assert
-    expected_versions_39 = [
-        'numpy==1.20.0',
-        'git+https://github.com/pandas-dev/pandas.git@master#egg=pandas',
-        'humanfriendly==8.2',
-    ]
-    expected_versions_310 = [
-        'numpy==1.23.3',
-        'git+https://github.com/pandas-dev/pandas.git@master#egg=pandas',
-        'humanfriendly==8.2',
-    ]
+    expected_versions_39 = {
+        'numpy': 'numpy==1.20.0',
+        'pandas': 'git+https://github.com/pandas-dev/pandas.git@master#egg=pandas',
+        'humanfriendly': 'humanfriendly==8.2',
+    }
+    expected_versions_310 = {
+        'numpy': 'numpy==1.23.3',
+        'pandas': 'git+https://github.com/pandas-dev/pandas.git@master#egg=pandas',
+        'humanfriendly': 'humanfriendly==8.2',
+    }
 
     assert minimum_versions_39 == expected_versions_39
     assert minimum_versions_310 == expected_versions_310
+
+
+def _get_example_pyproject_dict():
+    return {
+        'build-system': {
+            'build-backend': 'setuptools.build_meta',
+            'requires': ['setuptools', 'wheel']
+        },
+        'project': {
+            'authors': [{'email': 'info@sdv.dev', 'name': 'DataCebo, Inc.'}],
+            'classifiers': [
+                'Intended Audience :: Developers',
+                'License :: Free for non-commercial use',
+                'Natural Language :: English',
+                'Programming Language :: Python :: 3.10',
+                'Programming Language :: Python :: 3.11',
+                'Programming Language :: Python :: 3.12',
+                'Topic :: Scientific/Engineering :: Artificial '
+                'Intelligence'
+            ],
+            'dependencies': [
+                'appdirs>=1.3',
+                'boto3>=1.28,<2',
+                'botocore>=1.31,<2',
+                'cloudpickle>=2.1.0',
+                'compress-pickle>=1.2.0',
+                'humanfriendly>=8.2',
+                "numpy>=1.21.6;python_version<'3.10'",
+                "numpy>=1.23.3;python_version>='3.10' and python_version<'3.12'",
+                "numpy>=1.26.0;python_version>='3.12'",
+                "pandas>=1.4.0;python_version<'3.11'",
+                "pandas>=1.5.0;python_version>='3.11' and python_version<'3.12'",
+                "pandas>=2.1.1;python_version>='3.12'",
+                'psutil>=5.7',
+                "scikit-learn>=1.0.2;python_version<'3.10'",
+                "scikit-learn>=1.1.0;python_version>='3.10' and python_version<'3.11'",
+                "scikit-learn>=1.1.3;python_version>='3.11' and python_version<'3.12'",
+                "scikit-learn>=1.3.1;python_version>='3.12'",
+                "scipy>=1.7.3;python_version<'3.10'",
+                "scipy>=1.9.2;python_version>='3.10' and python_version<'3.12'",
+                "scipy>=1.12.0;python_version>='3.12'",
+                'tabulate>=0.8.3,<0.9',
+                "torch>=1.12.1;python_version<'3.10'",
+                "torch>=2.0.0;python_version>='3.10' and python_version<'3.12'",
+                "torch>=2.2.0;python_version>='3.12'",
+                'tqdm>=4.66.3',
+                'XlsxWriter>=1.2.8',
+                'rdt>=1.13.1',
+                'sdmetrics>=0.17.0',
+                'sdv>=1.17.2'
+            ],
+            'dynamic': ['version'],
+            'license': {'text': 'BSL-1.1'},
+            'name': 'sdgym',
+            'optional-dependencies': {
+                'all': ['sdgym[dask, test, dev]'],
+                'dask': ['dask', 'distributed'],
+                'dev': [
+                    'sdgym[dask, test]',
+                    'build>=1.0.0,<2',
+                    'bump-my-version>=0.18.3,<1',
+                    'pip>=9.0.1',
+                    'watchdog>=1.0.1,<5',
+                    'ruff>=0.4.5,<1',
+                    'twine>=1.10.0,<6',
+                    'wheel>=0.30.0',
+                    'coverage>=4.5.12,<8',
+                    'tox>=2.9.1,<5',
+                    'importlib-metadata>=3.6',
+                    'invoke'
+                ],
+                'realtabformer': ['realtabformer>=0.2.1'],
+                'test': ['sdgym[realtabformer]', 'pytest>=6.2.5',]
+            },
+            'readme': 'README.md',
+            'requires-python': '>=3.8,<3.13',
+        },
+        'tool': {
+            'bumpversion': {
+                'allow_dirty': False,
+                'commit': True,
+                'commit_args': '',
+            },
+          'ruff': {
+                'exclude': [
+                    'docs',
+                    '.tox',
+                    '.git',
+                    '__pycache__',
+                    '.ipynb_checkpoints',
+                    'tasks.py'
+                ],
+                'indent-width': 4,
+            },
+        }
+    }
+
+
+def test__get_extra_dependencies():
+    """Test that the proper dependency strings are extracted from the pyproject dictionary."""
+    # Setup
+    pyproject_dict = _get_example_pyproject_dict()
+
+    # Run
+    extra_dependencies = _get_extra_dependencies(pyproject_dict)
+
+    # Assert
+    assert extra_dependencies == ['realtabformer>=0.2.1']
+
+
+def test__resolve_version_conflicts_conflicting_versions():
+    """Test that any conflictss for the same dependency are resolves to the higher version."""
+    # Setup
+    deps = {
+        'numpy': 'numpy==2.0.1',
+        'pandas': 'pandas==2.2.1',
+        'sdv': 'sdv==2.1.1',
+        'rdt': 'rdt==1.1.2'
+    }
+    extra_deps = {
+        'numpy': 'numpy==2.0.0',
+        'pandas': 'pandas==2.3.0',
+        'sdv': 'sdv==3.0.0',
+        'copulas': 'copulas==0.12.0'
+    }
+
+    # Run
+    versions = _resolve_version_conflicts(deps, extra_deps)
+
+    # Assert
+    assert sorted(versions) == sorted([
+        'numpy==2.0.1',
+        'pandas==2.3.0',
+        'sdv==3.0.0',
+        'rdt==1.1.2',
+        'copulas==0.12.0'
+    ])
+
+
+def test__resolve_version_conflicts_pointing_to_branch():
+    """Test that any conflictss for the same dependency are resolves to the higher version."""
+    # Setup
+    deps = {
+        'numpy': 'git+https://github.com/numpy-dev/numpy.git@master#egg=numpy',
+        'pandas': 'pandas==2.2.1',
+        'sdv': 'sdv==2.1.1',
+        'rdt': 'rdt==1.1.2'
+    }
+    extra_deps = {
+        'numpy': 'numpy==2.0.0',
+        'pandas': 'git+https://github.com/pandas-dev/pandas.git@master#egg=pandas',
+        'sdv': 'sdv==3.0.0',
+        'copulas': 'copulas==0.12.0'
+    }
+
+    # Run
+    versions = _resolve_version_conflicts(deps, extra_deps)
+
+    # Assert
+    assert sorted(versions) == sorted([
+        'git+https://github.com/numpy-dev/numpy.git@master#egg=numpy',
+        'git+https://github.com/pandas-dev/pandas.git@master#egg=pandas',
+        'sdv==3.0.0',
+        'rdt==1.1.2',
+        'copulas==0.12.0'
+    ])

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -43,7 +43,7 @@ def _get_example_pyproject_dict():
     return {
         'build-system': {
             'build-backend': 'setuptools.build_meta',
-            'requires': ['setuptools', 'wheel']
+            'requires': ['setuptools', 'wheel'],
         },
         'project': {
             'authors': [{'email': 'info@sdv.dev', 'name': 'DataCebo, Inc.'}],
@@ -54,8 +54,7 @@ def _get_example_pyproject_dict():
                 'Programming Language :: Python :: 3.10',
                 'Programming Language :: Python :: 3.11',
                 'Programming Language :: Python :: 3.12',
-                'Topic :: Scientific/Engineering :: Artificial '
-                'Intelligence'
+                'Topic :: Scientific/Engineering :: Artificial Intelligence',
             ],
             'dependencies': [
                 'appdirs>=1.3',
@@ -86,7 +85,7 @@ def _get_example_pyproject_dict():
                 'XlsxWriter>=1.2.8',
                 'rdt>=1.13.1',
                 'sdmetrics>=0.17.0',
-                'sdv>=1.17.2'
+                'sdv>=1.17.2',
             ],
             'dynamic': ['version'],
             'license': {'text': 'BSL-1.1'},
@@ -106,10 +105,13 @@ def _get_example_pyproject_dict():
                     'coverage>=4.5.12,<8',
                     'tox>=2.9.1,<5',
                     'importlib-metadata>=3.6',
-                    'invoke'
+                    'invoke',
                 ],
                 'realtabformer': ['realtabformer>=0.2.1'],
-                'test': ['sdgym[realtabformer]', 'pytest>=6.2.5',]
+                'test': [
+                    'sdgym[realtabformer]',
+                    'pytest>=6.2.5',
+                ]
             },
             'readme': 'README.md',
             'requires-python': '>=3.8,<3.13',
@@ -120,18 +122,18 @@ def _get_example_pyproject_dict():
                 'commit': True,
                 'commit_args': '',
             },
-          'ruff': {
+            'ruff': {
                 'exclude': [
                     'docs',
                     '.tox',
                     '.git',
                     '__pycache__',
                     '.ipynb_checkpoints',
-                    'tasks.py'
+                    'tasks.py',
                 ],
                 'indent-width': 4,
             },
-        }
+        },
     }
 
 
@@ -154,13 +156,13 @@ def test__resolve_version_conflicts_conflicting_versions():
         'numpy': 'numpy==2.0.1',
         'pandas': 'pandas==2.2.1',
         'sdv': 'sdv==2.1.1',
-        'rdt': 'rdt==1.1.2'
+        'rdt': 'rdt==1.1.2',
     }
     extra_deps = {
         'numpy': 'numpy==2.0.0',
         'pandas': 'pandas==2.3.0',
         'sdv': 'sdv==3.0.0',
-        'copulas': 'copulas==0.12.0'
+        'copulas': 'copulas==0.12.0',
     }
 
     # Run
@@ -172,7 +174,7 @@ def test__resolve_version_conflicts_conflicting_versions():
         'pandas==2.3.0',
         'sdv==3.0.0',
         'rdt==1.1.2',
-        'copulas==0.12.0'
+        'copulas==0.12.0',
     ])
 
 
@@ -183,13 +185,13 @@ def test__resolve_version_conflicts_pointing_to_branch():
         'numpy': 'git+https://github.com/numpy-dev/numpy.git@master#egg=numpy',
         'pandas': 'pandas==2.2.1',
         'sdv': 'sdv==2.1.1',
-        'rdt': 'rdt==1.1.2'
+        'rdt': 'rdt==1.1.2',
     }
     extra_deps = {
         'numpy': 'numpy==2.0.0',
         'pandas': 'git+https://github.com/pandas-dev/pandas.git@master#egg=pandas',
         'sdv': 'sdv==3.0.0',
-        'copulas': 'copulas==0.12.0'
+        'copulas': 'copulas==0.12.0',
     }
 
     # Run
@@ -201,5 +203,5 @@ def test__resolve_version_conflicts_pointing_to_branch():
         'git+https://github.com/pandas-dev/pandas.git@master#egg=pandas',
         'sdv==3.0.0',
         'rdt==1.1.2',
-        'copulas==0.12.0'
+        'copulas==0.12.0',
     ])

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -150,7 +150,7 @@ def test__get_extra_dependencies():
 
 
 def test__resolve_version_conflicts_conflicting_versions():
-    """Test that any conflictss for the same dependency are resolves to the higher version."""
+    """Test that any conflicts for the same dependency are resolved to the higher version."""
     # Setup
     deps = {
         'numpy': 'numpy==2.0.1',
@@ -179,7 +179,7 @@ def test__resolve_version_conflicts_conflicting_versions():
 
 
 def test__resolve_version_conflicts_pointing_to_branch():
-    """Test that any conflictss for the same dependency are resolves to the higher version."""
+    """Test specific branches are always selected over normal version numbers."""
     # Setup
     deps = {
         'numpy': 'git+https://github.com/numpy-dev/numpy.git@master#egg=numpy',


### PR DESCRIPTION
resolves #376

To fix failing integration tests and minimum tests, this PR:
- Bumps the minimum version of realtabformer
- Bumps the minimum version of torch when installing realtabformer
- Updates the script for the minimum tests to install extra dependencies and resolve conflicts if a dependency already exists (for example the main dependencies and realtabformer both list values for torch)

To speed up the integration tests this PR:
- Adds a private _MODEL_KWARGS attribute to the RealTabFormer so that the epochs can be overwritten