### PR TITLE
Speed up `test_benchmark_single_table_realtabformer_no_metrics` integration test 

### DIFF
--- a/sdgym/synthesizers/generate.py
+++ b/sdgym/synthesizers/generate.py
@@ -10,6 +10,7 @@ from sdv.single_table import (
 )
 
 from sdgym.synthesizers.base import BaselineSynthesizer, MultiSingleTableBaselineSynthesizer
+from sdgym.synthesizers.realtabformer import RealTabFormerSynthesizer
 from sdgym.synthesizers.sdv import SDVRelationalSynthesizer, SDVTabularSynthesizer
 
 SYNTHESIZER_MAPPING = {
@@ -19,6 +20,7 @@ SYNTHESIZER_MAPPING = {
     'TVAESynthesizer': TVAESynthesizer,
     'PARSynthesizer': PARSynthesizer,
     'HMASynthesizer': HMASynthesizer,
+    'RealTabFormerSynthesizer': RealTabFormerSynthesizer,
 }
 
 
@@ -55,6 +57,8 @@ def create_sdv_synthesizer_variant(display_name, synthesizer_class, synthesizer_
     baseclass = SDVTabularSynthesizer
     if synthesizer_class == 'HMASynthesizer':
         baseclass = SDVRelationalSynthesizer
+    if synthesizer_class == 'RealTabFormerSynthesizer':
+        baseclass = RealTabFormerSynthesizer
 
     class NewSynthesizer(baseclass):
         """New Synthesizer class.

--- a/tests/integration/test_benchmark.py
+++ b/tests/integration/test_benchmark.py
@@ -55,7 +55,6 @@ def test_benchmark_single_table_basic_synthsizers():
 def test_benchmark_single_table_realtabformer_no_metrics():
     """Test it without metrics."""
     # Run
-
     custom_synthesizer = create_sdv_synthesizer_variant(
         display_name='RealTabFormerSynthesizer',
         synthesizer_class='RealTabFormerSynthesizer',
@@ -66,7 +65,6 @@ def test_benchmark_single_table_realtabformer_no_metrics():
         custom_synthesizers=[custom_synthesizer],
         sdv_datasets=['fake_companies'],
         sdmetrics=[],
-        limit_dataset_size=True,
     )
 
     # Assert

--- a/tests/integration/test_benchmark.py
+++ b/tests/integration/test_benchmark.py
@@ -55,10 +55,18 @@ def test_benchmark_single_table_basic_synthsizers():
 def test_benchmark_single_table_realtabformer_no_metrics():
     """Test it without metrics."""
     # Run
+
+    custom_synthesizer = create_sdv_synthesizer_variant(
+        display_name='RealTabFormerSynthesizer',
+        synthesizer_class='RealTabFormerSynthesizer',
+        synthesizer_parameters={'epochs': 2},
+    )
     output = sdgym.benchmark_single_table(
-        synthesizers=['RealTabFormerSynthesizer'],
-        sdv_datasets=['student_placements'],
+        synthesizers=[],
+        custom_synthesizers=[custom_synthesizer],
+        sdv_datasets=['fake_companies'],
         sdmetrics=[],
+        limit_dataset_size=True,
     )
 
     # Assert


### PR DESCRIPTION
CU-86b3uhn4q, Resolve #379.

This PR speeds up the test from ~4min to ~30s on my M1 Mac.