### PR TITLE
Update the library installation script for EC2 machines to install optional dependencies like RealTabFormer

### DIFF
--- a/sdgym/benchmark.py
+++ b/sdgym/benchmark.py
@@ -647,6 +647,7 @@ import sdgym
 from sdgym.synthesizers.sdv import (CopulaGANSynthesizer, CTGANSynthesizer,
     GaussianCopulaSynthesizer, HMASynthesizer, PARSynthesizer, SDVRelationalSynthesizer,
     SDVTabularSynthesizer, TVAESynthesizer)
+from sdgym.synthesizers import RealTabFormerSynthesizer
 
 results = sdgym.benchmark_single_table(
     {synthesizer_string}, custom_synthesizers={params['custom_synthesizers']},
@@ -675,7 +676,7 @@ def _create_instance_on_ec2(script_content):
     sudo apt update -y
     sudo apt install python3-pip -y
     echo "======== Install Dependencies ============"
-    sudo pip3 install sdgym
+    sudo pip3 install sdgym[all]
     sudo pip3 install anyio
     pip3 list
     sudo apt install awscli -y
@@ -705,7 +706,7 @@ def _create_instance_on_ec2(script_content):
             {
                 'DeviceName': '/dev/sda1',
                 'Ebs': {
-                    'VolumeSize': 16,  # Specify the desired size in GB
+                    'VolumeSize': 32,  # Specify the desired size in GB
                     'VolumeType': 'gp2',  # Change the volume type as needed
                 },
             }


### PR DESCRIPTION
Resolve #388
Did one successfull run with 1 dataset, the results are stored [here](https://us-east-1.console.aws.amazon.com/s3/object/sdgym-benchmark?region=us-east-1&bucketType=general&prefix=Debug/Try_2_RealTabFormerSynthesizer_dataset_expedia_hotel_logs.csv)
s3://sdgym-benchmark/Debug/Try_2_RealTabFormerSynthesizer_dataset_expedia_hotel_logs.csv