### PR TITLE
Add ability to save synthesizers and data when running benchmark_single_table

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ dependencies = [
     'rdt>=1.17.0',
     'sdmetrics>=0.20.1',
     'sdv>=1.21.0',
-    'portalocker>=3.0.0',
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
     'rdt>=1.17.0',
     'sdmetrics>=0.20.1',
     'sdv>=1.21.0',
-    'portalocker>=3.2.0',
+    'portalocker>=3.0.0',
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dependencies = [
     'rdt>=1.17.0',
     'sdmetrics>=0.20.1',
     'sdv>=1.21.0',
+    'portalocker>=3.2.0',
 ]
 
 [project.urls]

--- a/sdgym/benchmark.py
+++ b/sdgym/benchmark.py
@@ -856,14 +856,13 @@ def _create_instance_on_ec2(script_content):
 
 
 def _handle_deprecated_parameters(
-    output_filepath, detailed_results_folder, multi_processing_config, run_on_ec2
+    output_filepath, detailed_results_folder, multi_processing_config
 ):
     """Handle deprecated parameters and issue warnings."""
     parameters_to_deprecate = {
         'output_filepath': output_filepath,
         'detailed_results_folder': detailed_results_folder,
         'multi_processing_config': multi_processing_config,
-        'run_on_ec2': run_on_ec2,
     }
     parameters = []
     for name, value in parameters_to_deprecate.items():
@@ -873,9 +872,10 @@ def _handle_deprecated_parameters(
     if parameters:
         parameters = "', '".join(sorted(parameters))
         message = (
-            f"Parameters '{parameters}' are deprecated in the `benchmark_single_table` "
+            f"Parameters '{parameters}' are deprecated in the 'benchmark_single_table' "
             'function and will be removed in October 2025. '
-            'Please consider using `output_destination` instead.'
+            "For saving results, please use the 'output_destination' parameter. For running SDGym"
+            " remotely on AWS please use the 'benchmark_single_table_aws' method."
         )
         warnings.warn(message, FutureWarning)
 
@@ -1024,9 +1024,7 @@ def benchmark_single_table(
         pandas.DataFrame:
             A table containing one row per synthesizer + dataset + metric.
     """
-    _handle_deprecated_parameters(
-        output_filepath, detailed_results_folder, multi_processing_config, run_on_ec2
-    )
+    _handle_deprecated_parameters(output_filepath, detailed_results_folder, multi_processing_config)
     if run_on_ec2:
         print("This will create an instance for the current AWS user's account.")  # noqa
         if output_filepath is not None:

--- a/sdgym/benchmark.py
+++ b/sdgym/benchmark.py
@@ -892,9 +892,6 @@ def _validate_output_destination(output_destination):
             'Please use `benchmark_single_table_aws` instead.'
         )
 
-    if os.path.exists(output_destination):
-        raise ValueError(f'The output path {output_destination} already exists.')
-
 
 def _write_run_id_file(output_destination, synthesizers, job_args_list):
     jobs = [[job[-3], job[0]['name']] for job in job_args_list]

--- a/sdgym/benchmark.py
+++ b/sdgym/benchmark.py
@@ -140,8 +140,8 @@ def _setup_output_destination(output_destination, synthesizers, datasets):
             synth_folder.mkdir(parents=True, exist_ok=True)
 
             paths[dataset][synth_name] = {
-                'synthesizer': str(synth_folder / 'synthesizer.pkl'),
-                'synthetic_data': str(synth_folder / 'synthetic_data.csv'),
+                'synthesizer': str(synth_folder / f'{synth_name}_synthesizer.pkl'),
+                'synthetic_data': str(synth_folder / f'{synth_name}_synthetic_data.csv'),
             }
 
     return paths

--- a/sdgym/benchmark.py
+++ b/sdgym/benchmark.py
@@ -14,6 +14,7 @@ from contextlib import contextmanager
 from datetime import datetime
 from importlib.metadata import version
 from pathlib import Path
+import portalocker
 
 import boto3
 import cloudpickle
@@ -548,6 +549,15 @@ def _format_output(
 
     return scores
 
+def safe_append(scores, result_file):
+    result_file = Path(result_file)
+    result_file.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(result_file, 'a+') as f:
+        portalocker.lock(f, portalocker.LOCK_EX)
+        f.seek(0, 2)
+        is_empty = f.tell() == 0
+        scores.to_csv(f, index=False, header=is_empty)
 
 def _run_job(args):
     # Reset random seed
@@ -622,10 +632,7 @@ def _run_job(args):
         synth_path = Path(synthesizer_path['synthesizer'])
         root_path = synth_path.parents[2]
         result_file = root_path / 'results.csv'
-        if not result_file.exists():
-            scores.to_csv(result_file, index=False, mode='w')
-        else:
-            scores.to_csv(result_file, index=False, mode='a', header=False)
+        safe_append(scores, result_file)
 
     return scores
 

--- a/sdgym/benchmark.py
+++ b/sdgym/benchmark.py
@@ -14,13 +14,13 @@ from contextlib import contextmanager
 from datetime import datetime
 from importlib.metadata import version
 from pathlib import Path
-import portalocker
 
 import boto3
 import cloudpickle
 import compress_pickle
 import numpy as np
 import pandas as pd
+import portalocker
 import tqdm
 import yaml
 from sdmetrics.reports.multi_table import (
@@ -549,7 +549,8 @@ def _format_output(
 
     return scores
 
-def safe_append(scores, result_file):
+
+def _safe_append(scores, result_file):
     result_file = Path(result_file)
     result_file.parent.mkdir(parents=True, exist_ok=True)
 
@@ -558,6 +559,7 @@ def safe_append(scores, result_file):
         f.seek(0, 2)
         is_empty = f.tell() == 0
         scores.to_csv(f, index=False, header=is_empty)
+
 
 def _run_job(args):
     # Reset random seed
@@ -632,7 +634,7 @@ def _run_job(args):
         synth_path = Path(synthesizer_path['synthesizer'])
         root_path = synth_path.parents[2]
         result_file = root_path / 'results.csv'
-        safe_append(scores, result_file)
+        _safe_append(scores, result_file)
 
     return scores
 

--- a/sdgym/benchmark.py
+++ b/sdgym/benchmark.py
@@ -553,12 +553,11 @@ def _format_output(
 def _safe_append(scores, result_file):
     result_file = Path(result_file)
     result_file.parent.mkdir(parents=True, exist_ok=True)
-
-    with open(result_file, 'a+') as f:
-        portalocker.lock(f, portalocker.LOCK_EX)
-        f.seek(0, 2)
-        is_empty = f.tell() == 0
-        scores.to_csv(f, index=False, header=is_empty)
+    with open(result_file, 'a+') as file:
+        portalocker.lock(file, portalocker.LOCK_EX)
+        file.seek(0, 2)
+        is_empty = file.tell() == 0
+        scores.to_csv(file, index=False, header=is_empty)
 
 
 def _run_job(args):

--- a/sdgym/benchmark.py
+++ b/sdgym/benchmark.py
@@ -779,6 +779,31 @@ def _create_instance_on_ec2(script_content):
     print(f'Job kicked off for SDGym on {instance_id}')  # noqa
 
 
+def _handle_deprecated_parameters(
+    output_filepath, detailed_results_folder, multi_processing_config, run_on_ec2
+):
+    """Handle deprecated parameters and issue warnings."""
+    parameters_to_deprecate = {
+        'output_filepath': output_filepath,
+        'detailed_results_folder': detailed_results_folder,
+        'multi_processing_config': multi_processing_config,
+        'run_on_ec2': run_on_ec2,
+    }
+    parameters = []
+    for name, value in parameters_to_deprecate.items():
+        if value is not None and value:
+            parameters.append(name)
+
+    if parameters:
+        parameters = "', '".join(sorted(parameters))
+        message = (
+            f"Parameters '{parameters}' are deprecated in the `benchmark_single_table` "
+            'function and will be removed in October 2025. '
+            'Please consider using `output_destination` instead.'
+        )
+        warnings.warn(message, FutureWarning)
+
+
 def benchmark_single_table(
     synthesizers=DEFAULT_SYNTHESIZERS,
     custom_synthesizers=None,
@@ -863,6 +888,9 @@ def benchmark_single_table(
         pandas.DataFrame:
             A table containing one row per synthesizer + dataset + metric.
     """
+    _handle_deprecated_parameters(
+        output_filepath, detailed_results_folder, multi_processing_config, run_on_ec2
+    )
     if run_on_ec2:
         print("This will create an instance for the current AWS user's account.")  # noqa
         if output_filepath is not None:

--- a/tests/integration/test_benchmark.py
+++ b/tests/integration/test_benchmark.py
@@ -605,45 +605,49 @@ def test_benchmark_single_table_with_output_destination(tmp_path):
     # Assert
     directions = os.listdir(output_destination)
     score_saved_separately = pd.DataFrame()
-    assert f'SDGym_results_{today_date}' in directions
-    for file in directions:
-        if file.endswith('.yaml'):
-            with open(os.path.join(output_destination, file), 'r') as f:
-                metadata = yaml.safe_load(f)
-                assert metadata['completed_date'] is not None
-                assert metadata['sdgym_version'] == sdgym.__version__
-        else:
-            subdirections = os.listdir(os.path.join(output_destination, file))
-            assert set(subdirections) == {'results.csv', f'fake_companies_{today_date}'}
-            synthesizer_directions = os.listdir(
-                os.path.join(output_destination, file, f'fake_companies_{today_date}')
-            )
-            assert set(synthesizer_directions) == {'TVAESynthesizer', 'GaussianCopulaSynthesizer'}
-            for synthesizer in sorted(synthesizer_directions):
-                synthesizer_files = os.listdir(
-                    os.path.join(
-                        output_destination, file, f'fake_companies_{today_date}', synthesizer
-                    )
-                )
-                assert set(synthesizer_files) == {
-                    f'{synthesizer}_synthesizer.pkl',
-                    f'{synthesizer}_synthetic_data.csv',
-                    f'{synthesizer}_benchmark_result.csv',
-                }
-                score = pd.read_csv(
-                    os.path.join(
-                        output_destination,
-                        file,
-                        f'fake_companies_{today_date}',
-                        synthesizer,
-                        f'{synthesizer}_benchmark_result.csv',
-                    )
-                )
-                score_saved_separately = pd.concat(
-                    [score_saved_separately, score], ignore_index=True
-                )
+    assert directions == [f'SDGym_results_{today_date}']
+    subdirections = os.listdir(os.path.join(output_destination, directions[0]))
+    assert set(subdirections) == {
+        f'results_{today_date}_1.csv',
+        f'fake_companies_{today_date}',
+        f'run_{today_date}_1.yaml',
+    }
+    with open(
+        os.path.join(output_destination, directions[0], f'run_{today_date}_1.yaml'), 'r'
+    ) as f:
+        metadata = yaml.safe_load(f)
+        assert metadata['completed_date'] is not None
+        assert metadata['sdgym_version'] == sdgym.__version__
 
-    saved_result = pd.read_csv(f'{output_destination}/SDGym_results_{today_date}/results.csv')
+    synthesizer_directions = os.listdir(
+        os.path.join(output_destination, directions[0], f'fake_companies_{today_date}')
+    )
+    assert set(synthesizer_directions) == {'TVAESynthesizer', 'GaussianCopulaSynthesizer'}
+    for synthesizer in sorted(synthesizer_directions):
+        synthesizer_files = os.listdir(
+            os.path.join(
+                output_destination, directions[0], f'fake_companies_{today_date}', synthesizer
+            )
+        )
+        assert set(synthesizer_files) == {
+            f'{synthesizer}_synthesizer.pkl',
+            f'{synthesizer}_synthetic_data.csv',
+            f'{synthesizer}_benchmark_result.csv',
+        }
+        score = pd.read_csv(
+            os.path.join(
+                output_destination,
+                directions[0],
+                f'fake_companies_{today_date}',
+                synthesizer,
+                f'{synthesizer}_benchmark_result.csv',
+            )
+        )
+        score_saved_separately = pd.concat([score_saved_separately, score], ignore_index=True)
+
+    saved_result = pd.read_csv(
+        f'{output_destination}/SDGym_results_{today_date}/results_{today_date}_1.csv'
+    )
     pd.testing.assert_frame_equal(results, saved_result, check_dtype=False)
     pd.testing.assert_frame_equal(results, score_saved_separately, check_dtype=False)
 
@@ -673,47 +677,55 @@ def test_benchmark_single_table_with_output_destination_multiple_runs(tmp_path):
     )
 
     # Assert
-    final_results = pd.concat([result_1, result_2], ignore_index=True)
     score_saved_separately = pd.DataFrame()
     directions = os.listdir(output_destination)
-    assert f'SDGym_results_{today_date}' in directions
-    for file in directions:
-        if file.endswith('.yaml'):
-            with open(os.path.join(output_destination, file), 'r') as f:
-                metadata = yaml.safe_load(f)
-                assert metadata['completed_date'] is not None
-                assert metadata['sdgym_version'] == sdgym.__version__
-        else:
-            subdirections = os.listdir(os.path.join(output_destination, file))
-            assert set(subdirections) == {'results.csv', f'fake_companies_{today_date}'}
-            synthesizer_directions = os.listdir(
-                os.path.join(output_destination, file, f'fake_companies_{today_date}')
-            )
-            assert set(synthesizer_directions) == {'TVAESynthesizer', 'GaussianCopulaSynthesizer'}
-            for synthesizer in sorted(synthesizer_directions):
-                synthesizer_files = os.listdir(
-                    os.path.join(
-                        output_destination, file, f'fake_companies_{today_date}', synthesizer
-                    )
-                )
-                assert set(synthesizer_files) == {
-                    f'{synthesizer}_synthesizer.pkl',
-                    f'{synthesizer}_synthetic_data.csv',
-                    f'{synthesizer}_benchmark_result.csv',
-                }
-                score = pd.read_csv(
-                    os.path.join(
-                        output_destination,
-                        file,
-                        f'fake_companies_{today_date}',
-                        synthesizer,
-                        f'{synthesizer}_benchmark_result.csv',
-                    )
-                )
-                score_saved_separately = pd.concat(
-                    [score_saved_separately, score], ignore_index=True
-                )
+    assert directions == [f'SDGym_results_{today_date}']
+    subdirections = os.listdir(os.path.join(output_destination, directions[0]))
+    assert set(subdirections) == {
+        f'results_{today_date}_1.csv',
+        f'results_{today_date}_2.csv',
+        f'fake_companies_{today_date}',
+        f'run_{today_date}_1.yaml',
+        f'run_{today_date}_2.yaml',
+    }
+    with open(
+        os.path.join(output_destination, directions[0], f'run_{today_date}_1.yaml'), 'r'
+    ) as f:
+        metadata = yaml.safe_load(f)
+        assert metadata['completed_date'] is not None
+        assert metadata['sdgym_version'] == sdgym.__version__
 
-    saved_result = pd.read_csv(f'{output_destination}/SDGym_results_{today_date}/results.csv')
-    pd.testing.assert_frame_equal(final_results, saved_result, check_dtype=False)
-    pd.testing.assert_frame_equal(final_results, score_saved_separately, check_dtype=False)
+    synthesizer_directions = os.listdir(
+        os.path.join(output_destination, directions[0], f'fake_companies_{today_date}')
+    )
+    assert set(synthesizer_directions) == {'TVAESynthesizer', 'GaussianCopulaSynthesizer'}
+    for synthesizer in sorted(synthesizer_directions):
+        synthesizer_files = os.listdir(
+            os.path.join(
+                output_destination, directions[0], f'fake_companies_{today_date}', synthesizer
+            )
+        )
+        assert set(synthesizer_files) == {
+            f'{synthesizer}_synthesizer.pkl',
+            f'{synthesizer}_synthetic_data.csv',
+            f'{synthesizer}_benchmark_result.csv',
+        }
+        score = pd.read_csv(
+            os.path.join(
+                output_destination,
+                directions[0],
+                f'fake_companies_{today_date}',
+                synthesizer,
+                f'{synthesizer}_benchmark_result.csv',
+            )
+        )
+        score_saved_separately = pd.concat([score_saved_separately, score], ignore_index=True)
+
+    saved_result_1 = pd.read_csv(
+        f'{output_destination}/SDGym_results_{today_date}/results_{today_date}_1.csv'
+    )
+    saved_result_2 = pd.read_csv(
+        f'{output_destination}/SDGym_results_{today_date}/results_{today_date}_2.csv'
+    )
+    pd.testing.assert_frame_equal(result_1, saved_result_1, check_dtype=False)
+    pd.testing.assert_frame_equal(result_2, saved_result_2, check_dtype=False)

--- a/tests/integration/test_benchmark.py
+++ b/tests/integration/test_benchmark.py
@@ -598,7 +598,7 @@ def test_benchmark_single_table_with_output_destination(tmp_path):
     # Run
     results = benchmark_single_table(
         synthesizers=['GaussianCopulaSynthesizer', 'TVAESynthesizer'],
-        sdv_datasets=['expedia_hotel_logs'],
+        sdv_datasets=['fake_companies'],
         output_destination=output_destination,
     )
 
@@ -613,18 +613,21 @@ def test_benchmark_single_table_with_output_destination(tmp_path):
                 assert metadata['sdgym_version'] == sdgym.__version__
         else:
             subdirections = os.listdir(os.path.join(output_destination, file))
-            assert set(subdirections) == {'results.csv', f'expedia_hotel_logs_{today_date}'}
+            assert set(subdirections) == {'results.csv', f'fake_companies_{today_date}'}
             synthesizer_directions = os.listdir(
-                os.path.join(output_destination, file, f'expedia_hotel_logs_{today_date}')
+                os.path.join(output_destination, file, f'fake_companies_{today_date}')
             )
             assert set(synthesizer_directions) == {'TVAESynthesizer', 'GaussianCopulaSynthesizer'}
             for synthesizer in synthesizer_directions:
                 synthesizer_files = os.listdir(
                     os.path.join(
-                        output_destination, file, f'expedia_hotel_logs_{today_date}', synthesizer
+                        output_destination, file, f'fake_companies_{today_date}', synthesizer
                     )
                 )
-                assert set(synthesizer_files) == {'synthesizer.pkl', 'synthetic_data.csv'}
+                assert set(synthesizer_files) == {
+                    f'{synthesizer}_synthesizer.pkl',
+                    f'{synthesizer}_synthetic_data.csv',
+                }
 
     saved_result = pd.read_csv(f'{output_destination}/SDGym_results_{today_date}/results.csv')
     pd.testing.assert_frame_equal(results, saved_result, check_dtype=False)
@@ -645,12 +648,12 @@ def test_benchmark_single_table_with_output_destination_multiple_runs(tmp_path):
     # Run
     result_1 = benchmark_single_table(
         synthesizers=['GaussianCopulaSynthesizer'],
-        sdv_datasets=['expedia_hotel_logs'],
+        sdv_datasets=['fake_companies'],
         output_destination=output_destination,
     )
     result_2 = benchmark_single_table(
         synthesizers=['TVAESynthesizer'],
-        sdv_datasets=['expedia_hotel_logs'],
+        sdv_datasets=['fake_companies'],
         output_destination=output_destination,
     )
 
@@ -666,18 +669,21 @@ def test_benchmark_single_table_with_output_destination_multiple_runs(tmp_path):
                 assert metadata['sdgym_version'] == sdgym.__version__
         else:
             subdirections = os.listdir(os.path.join(output_destination, file))
-            assert set(subdirections) == {'results.csv', f'expedia_hotel_logs_{today_date}'}
+            assert set(subdirections) == {'results.csv', f'fake_companies_{today_date}'}
             synthesizer_directions = os.listdir(
-                os.path.join(output_destination, file, f'expedia_hotel_logs_{today_date}')
+                os.path.join(output_destination, file, f'fake_companies_{today_date}')
             )
             assert set(synthesizer_directions) == {'TVAESynthesizer', 'GaussianCopulaSynthesizer'}
             for synthesizer in synthesizer_directions:
                 synthesizer_files = os.listdir(
                     os.path.join(
-                        output_destination, file, f'expedia_hotel_logs_{today_date}', synthesizer
+                        output_destination, file, f'fake_companies_{today_date}', synthesizer
                     )
                 )
-                assert set(synthesizer_files) == {'synthesizer.pkl', 'synthetic_data.csv'}
+                assert set(synthesizer_files) == {
+                    f'{synthesizer}_synthesizer.pkl',
+                    f'{synthesizer}_synthetic_data.csv',
+                }
 
     saved_result = pd.read_csv(f'{output_destination}/SDGym_results_{today_date}/results.csv')
     pd.testing.assert_frame_equal(final_results, saved_result, check_dtype=False)

--- a/tests/integration/test_benchmark.py
+++ b/tests/integration/test_benchmark.py
@@ -604,6 +604,7 @@ def test_benchmark_single_table_with_output_destination(tmp_path):
 
     # Assert
     directions = os.listdir(output_destination)
+    score_saved_separately = pd.DataFrame()
     assert f'SDGym_results_{today_date}' in directions
     for file in directions:
         if file.endswith('.yaml'):
@@ -618,7 +619,7 @@ def test_benchmark_single_table_with_output_destination(tmp_path):
                 os.path.join(output_destination, file, f'fake_companies_{today_date}')
             )
             assert set(synthesizer_directions) == {'TVAESynthesizer', 'GaussianCopulaSynthesizer'}
-            for synthesizer in synthesizer_directions:
+            for synthesizer in sorted(synthesizer_directions):
                 synthesizer_files = os.listdir(
                     os.path.join(
                         output_destination, file, f'fake_companies_{today_date}', synthesizer
@@ -627,10 +628,24 @@ def test_benchmark_single_table_with_output_destination(tmp_path):
                 assert set(synthesizer_files) == {
                     f'{synthesizer}_synthesizer.pkl',
                     f'{synthesizer}_synthetic_data.csv',
+                    f'{synthesizer}_benchmark_result.csv',
                 }
+                score = pd.read_csv(
+                    os.path.join(
+                        output_destination,
+                        file,
+                        f'fake_companies_{today_date}',
+                        synthesizer,
+                        f'{synthesizer}_benchmark_result.csv',
+                    )
+                )
+                score_saved_separately = pd.concat(
+                    [score_saved_separately, score], ignore_index=True
+                )
 
     saved_result = pd.read_csv(f'{output_destination}/SDGym_results_{today_date}/results.csv')
     pd.testing.assert_frame_equal(results, saved_result, check_dtype=False)
+    pd.testing.assert_frame_equal(results, score_saved_separately, check_dtype=False)
 
 
 def test_benchmark_single_table_with_output_destination_multiple_runs(tmp_path):
@@ -659,6 +674,7 @@ def test_benchmark_single_table_with_output_destination_multiple_runs(tmp_path):
 
     # Assert
     final_results = pd.concat([result_1, result_2], ignore_index=True)
+    score_saved_separately = pd.DataFrame()
     directions = os.listdir(output_destination)
     assert f'SDGym_results_{today_date}' in directions
     for file in directions:
@@ -674,7 +690,7 @@ def test_benchmark_single_table_with_output_destination_multiple_runs(tmp_path):
                 os.path.join(output_destination, file, f'fake_companies_{today_date}')
             )
             assert set(synthesizer_directions) == {'TVAESynthesizer', 'GaussianCopulaSynthesizer'}
-            for synthesizer in synthesizer_directions:
+            for synthesizer in sorted(synthesizer_directions):
                 synthesizer_files = os.listdir(
                     os.path.join(
                         output_destination, file, f'fake_companies_{today_date}', synthesizer
@@ -683,7 +699,21 @@ def test_benchmark_single_table_with_output_destination_multiple_runs(tmp_path):
                 assert set(synthesizer_files) == {
                     f'{synthesizer}_synthesizer.pkl',
                     f'{synthesizer}_synthetic_data.csv',
+                    f'{synthesizer}_benchmark_result.csv',
                 }
+                score = pd.read_csv(
+                    os.path.join(
+                        output_destination,
+                        file,
+                        f'fake_companies_{today_date}',
+                        synthesizer,
+                        f'{synthesizer}_benchmark_result.csv',
+                    )
+                )
+                score_saved_separately = pd.concat(
+                    [score_saved_separately, score], ignore_index=True
+                )
 
     saved_result = pd.read_csv(f'{output_destination}/SDGym_results_{today_date}/results.csv')
     pd.testing.assert_frame_equal(final_results, saved_result, check_dtype=False)
+    pd.testing.assert_frame_equal(final_results, score_saved_separately, check_dtype=False)

--- a/tests/unit/test_benchmark.py
+++ b/tests/unit/test_benchmark.py
@@ -394,6 +394,9 @@ def test__setup_output_destination(mock_validate, tmp_path):
                     'synthetic_data': str(
                         base_path / f'{dataset}_{today}' / synth / f'{synth}_synthetic_data.csv'
                     ),
+                    'benchmark_result': str(
+                        base_path / f'{dataset}_{today}' / synth / f'{synth}_benchmark_result.csv'
+                    ),
                 }
                 for synth in synthesizers
             },

--- a/tests/unit/test_benchmark.py
+++ b/tests/unit/test_benchmark.py
@@ -422,7 +422,7 @@ def test__write_run_id_file(mock_datetime, mock_uuid, tmp_path):
         ({'name': 'GaussianCopulaSynthesizer'}, 'adult', None, None),
         ({'name': 'CTGANSynthesizer'}, 'census', None, None),
     ]
-    expected_jobs = [['GaussianCopulaSynthesizer', 'adult'], ['CTGANSynthesizer', 'census']]
+    expected_jobs = [['adult', 'GaussianCopulaSynthesizer'], ['census', 'CTGANSynthesizer']]
     synthesizers = ['GaussianCopulaSynthesizer', 'CTGANSynthesizer', 'RealTabFormerSynthesizer']
 
     # Run

--- a/tests/unit/test_benchmark.py
+++ b/tests/unit/test_benchmark.py
@@ -388,10 +388,10 @@ def test__setup_output_destination(mock_validate, tmp_path):
             **{
                 synth: {
                     'synthesizer': str(
-                        base_path / f'{dataset}_{today}' / synth / 'synthesizer.pkl'
+                        base_path / f'{dataset}_{today}' / synth / f'{synth}_synthesizer.pkl'
                     ),
                     'synthetic_data': str(
-                        base_path / f'{dataset}_{today}' / synth / 'synthetic_data.csv'
+                        base_path / f'{dataset}_{today}' / synth / f'{synth}_synthetic_data.csv'
                     ),
                 }
                 for synth in synthesizers

--- a/tests/unit/test_benchmark.py
+++ b/tests/unit/test_benchmark.py
@@ -357,7 +357,6 @@ def test__validate_output_destination(tmp_path):
         'The `output_destination` parameter cannot be an S3 path. '
         'Please use `benchmark_single_table_aws` instead.'
     )
-    err_3 = re.escape(f'The output path {valid_destination} already exists.')
 
     # Run and Assert
     _validate_output_destination(str(valid_destination))
@@ -366,10 +365,6 @@ def test__validate_output_destination(tmp_path):
 
     with pytest.raises(ValueError, match=err_2):
         _validate_output_destination(aws_destination)
-
-    valid_destination.mkdir()
-    with pytest.raises(ValueError, match=err_3):
-        _validate_output_destination(str(valid_destination))
 
 
 @patch('sdgym.benchmark._validate_output_destination')

--- a/tests/unit/test_benchmark.py
+++ b/tests/unit/test_benchmark.py
@@ -59,7 +59,7 @@ def test_benchmark_single_table_deprecated_params(mock_handle_deprecated, tqdm_m
     )
 
     # Assert
-    mock_handle_deprecated.assert_called_once_with(None, None, None, False)
+    mock_handle_deprecated.assert_called_once_with(None, None, None)
     tqdm_mock.assert_called_once_with(ANY, total=1, position=0, leave=True)
 
 
@@ -321,26 +321,27 @@ def test__handle_deprecated_parameters():
     output_filepath = 's3://BucketName/path'
     detailed_results_folder = 'mock/path'
     multi_processing_config = {'num_processes': 4}
-    run_on_ec2 = True
-    expected_message_1 = re.escape(
+    expected_message_1 = (
         "Parameters 'detailed_results_folder', 'output_filepath' are deprecated in the "
-        '`benchmark_single_table` function and will be removed in October 2025. Please '
-        'consider using `output_destination` instead.'
+        "'benchmark_single_table' function and will be removed in October 2025. For saving"
+        " results, please use the 'output_destination' parameter. For running SDGym remotely"
+        " on AWS please use the 'benchmark_single_table_aws' method."
     )
-    expected_message_2 = re.escape(
+    expected_message_2 = (
         "Parameters 'detailed_results_folder', 'multi_processing_config', 'output_filepath'"
-        ", 'run_on_ec2' are deprecated in the `benchmark_single_table` function and will be"
-        ' removed in October 2025. Please consider using `output_destination` instead.'
+        " are deprecated in the 'benchmark_single_table' function and will be removed in October"
+        " 2025. For saving results, please use the 'output_destination' parameter. For running"
+        " SDGym remotely on AWS please use the 'benchmark_single_table_aws' method."
     )
 
     # Run and Assert
-    _handle_deprecated_parameters(None, None, None, False)
+    _handle_deprecated_parameters(None, None, None)
     with pytest.warns(FutureWarning, match=expected_message_1):
-        _handle_deprecated_parameters(output_filepath, detailed_results_folder, None, False)
+        _handle_deprecated_parameters(output_filepath, detailed_results_folder, None)
 
     with pytest.warns(FutureWarning, match=expected_message_2):
         _handle_deprecated_parameters(
-            output_filepath, detailed_results_folder, multi_processing_config, run_on_ec2
+            output_filepath, detailed_results_folder, multi_processing_config
         )
 
 


### PR DESCRIPTION
Resolve #410
CU-86b5dy0pa

Thanks in advance for the review. Here are a few questions:
1. Should we crash if the `output_destination` already exists? Or should we always be overwriting (for instance if two benchmark are launched the same day)
2. What should include the `meta.yaml` file that is expected to be saved in `SDGym_results_mm_dd_yyyy/<dataset_name_mm_dd_yyyy>`? I did not create it yet because I was not sure what to put inside it.
3. Compared to the naming given in the issue:
    - I don't save with underscores at the end (`synthetic_data.csv` instead of `_synthetic_data.csv`), is it okay?
    - The `run<id>.yaml` is at the output_destination as well as the `SDGym_results_mm_dd_yyyy` is it correct or should it be inside `SDGym_results_mm_dd_yyyy`?
    - All the results combined are saved in a results.csv file that is in `SDGym_results_mm_dd_yyyy`
4. In `run<id>.yaml` I defined the starting_date and completed_date that correspond to the time the benchmark was started and fully commpleted.