### PR TITLE
Always include UniformSynthesizer doesn't work on AWS

### DIFF
--- a/sdgym/benchmark.py
+++ b/sdgym/benchmark.py
@@ -1364,7 +1364,7 @@ def _get_user_data_script(access_key, secret_key, region_name, script_content):
 
         echo "======== Install Dependencies in venv ============"
         pip install --upgrade pip
-        pip install "sdgym[all] @ git+https://github.com/sdv-dev/SDGym.git@issue-438-fix-benchmark-aws"
+        pip install "sdgym[all] @ git+https://github.com/sdv-dev/SDGym.git@main"
         pip install s3fs
 
         echo "======== Write Script ==========="

--- a/tests/unit/test_benchmark.py
+++ b/tests/unit/test_benchmark.py
@@ -230,7 +230,7 @@ def test__ensure_uniform_included_adds_uniform(caplog):
         _ensure_uniform_included(synthesizers)
 
     # Assert
-    assert synthesizers == [GaussianCopulaSynthesizer, UniformSynthesizer]
+    assert synthesizers == [GaussianCopulaSynthesizer, 'UniformSynthesizer']
     assert any(expected_message in record.message for record in caplog.records)
 
 
@@ -701,7 +701,7 @@ def test_benchmark_single_table_aws(
     )
 
     # Assert
-    assert UniformSynthesizer in synthesizers
+    assert 'UniformSynthesizer' in synthesizers
     mock_validate_output_destination.assert_called_once_with(
         output_destination,
         aws_keys={
@@ -777,14 +777,14 @@ def test_benchmark_single_table_aws_synthesizers_none(
         compute_quality_score=True,
         compute_diagnostic_score=True,
         compute_privacy_score=True,
-        synthesizers=[UniformSynthesizer],
+        synthesizers=['UniformSynthesizer'],
         detailed_results_folder=None,
         custom_synthesizers=None,
         s3_client='s3_client_mock',
     )
     mock_run_on_aws.assert_called_once_with(
         output_destination=output_destination,
-        synthesizers=[UniformSynthesizer],
+        synthesizers=['UniformSynthesizer'],
         s3_client='s3_client_mock',
         job_args_list='job_args_list_mock',
         aws_access_key_id='12345',


### PR DESCRIPTION
Resolve #446
CU-86b6z43bm

I tried running the following on aws:
```python
OUTPUT_DESTINATION_AWS = 's3://sdgym-benchmark/Debug/'
benchmark_single_table_aws(
    output_destination=OUTPUT_DESTINATION_AWS,
    aws_access_key_id=access_key,
    aws_secret_access_key=secret_key,
    synthesizers=['GaussianCopulaSynthesizer'],
    sdv_datasets=['expedia_hotel_logs'],
    compute_privacy_score=False,
)
```

The results are [here](https://us-east-1.console.aws.amazon.com/s3/buckets/sdgym-benchmark?prefix=Debug%2FSDGym_results_10_06_2025%2F&region=us-east-1&bucketType=general&tab=objects)