### PR TITLE
Adjusted time and quality score not aggregating correctly on EC2

### DIFF
--- a/sdgym/benchmark.py
+++ b/sdgym/benchmark.py
@@ -1091,7 +1091,7 @@ def _ensure_uniform_included(synthesizers):
         synthesizers.append('UniformSynthesizer')
 
 
-def _fill_adjusted_scores_with_nan(scores):
+def _fill_adjusted_scores_with_none(scores):
     """Fill adjusted total time and quality score with NaN values."""
     scores['Adjusted_Total_Time'] = None
     if 'Quality_Score' in scores.columns:
@@ -1105,7 +1105,7 @@ def _add_adjusted_scores(scores, timeout):
     timeout = timeout or 0
     uniform_mask = scores['Synthesizer'].str.contains('UniformSynthesizer', na=False)
     if not uniform_mask.any():
-        return _fill_adjusted_scores_with_nan(scores)
+        return _fill_adjusted_scores_with_none(scores)
 
     uniform_row = scores.loc[uniform_mask].iloc[0]
     base_fit_time = uniform_row.get('Train_Time')
@@ -1113,7 +1113,7 @@ def _add_adjusted_scores(scores, timeout):
     base_quality_score = uniform_row.get('Quality_Score', None)
 
     if pd.isna(base_fit_time) or pd.isna(base_sample_time):
-        return _fill_adjusted_scores_with_nan(scores)
+        return _fill_adjusted_scores_with_none(scores)
 
     fit_times = scores['Train_Time'].fillna(0)
     sample_times = scores['Sample_Time'].fillna(0)
@@ -1418,7 +1418,7 @@ def _get_user_data_script(access_key, secret_key, region_name, script_content):
 
         echo "======== Install Dependencies in venv ============"
         pip install --upgrade pip
-        pip install "sdgym[all] @ git+https://github.com/sdv-dev/SDGym.git@fix-aggregate-results-ec2"
+        pip install sdgym[all]
         pip install s3fs
 
         echo "======== Write Script ==========="

--- a/tests/unit/test_benchmark.py
+++ b/tests/unit/test_benchmark.py
@@ -18,6 +18,7 @@ from sdgym.benchmark import (
     _create_sdgym_script,
     _directory_exists,
     _ensure_uniform_included,
+    _fill_adjusted_scores_with_none,
     _format_output,
     _get_metainfo_increment,
     _handle_deprecated_parameters,
@@ -887,6 +888,40 @@ def test__add_adjusted_scores_no_failures():
     assert scores.equals(expected)
 
 
+def test__fill_adjusted_scores_with_none():
+    """Test the `_fill_adjusted_scores_with_none` method."""
+    # Setup
+    scores_1 = pd.DataFrame({
+        'Synthesizer': ['Synth1', 'Synth2'],
+        'Train_Time': [1.0, None],
+        'Sample_Time': [2.0, 3.0],
+        'Quality_Score': [0.8, None],
+    })
+    scores_2 = pd.DataFrame({
+        'Synthesizer': ['Synth1', 'Synth2'],
+        'Train_Time': [1.0, None],
+        'Sample_Time': [2.0, 3.0],
+    })
+    expected = pd.DataFrame({
+        'Synthesizer': ['Synth1', 'Synth2'],
+        'Train_Time': [1.0, None],
+        'Sample_Time': [2.0, 3.0],
+        'Quality_Score': [0.8, None],
+        'Adjusted_Total_Time': None,
+        'Adjusted_Quality_Score': None,
+    })
+
+    # Run
+    result_1 = _fill_adjusted_scores_with_none(scores_1)
+    result_2 = _fill_adjusted_scores_with_none(scores_2)
+
+    # Assert
+    pd.testing.assert_frame_equal(result_1, expected)
+    pd.testing.assert_frame_equal(
+        result_2, expected.drop(columns=['Quality_Score', 'Adjusted_Quality_Score'])
+    )
+
+
 def test__add_adjusted_scores_timeout():
     """Test _add_adjusted_scores when a synthesizer times out."""
     # Setup
@@ -945,18 +980,18 @@ def test__add_adjusted_scores_missing_fallback():
     """Test _add_adjusted_scores with the UniformSynthesizer row missing."""
     # Setup
     scores = pd.DataFrame({
-        'Synthesizer': ['GaussianCopulaSynthesizer'],
-        'Train_Time': [1.0],
-        'Sample_Time': [2.0],
-        'Quality_Score': [1.0],
+        'Synthesizer': ['GaussianCopulaSynthesizer', 'CTGANSynthesizer'],
+        'Train_Time': [1.0, 3.0],
+        'Sample_Time': [2.0, 1.0],
+        'Quality_Score': [1.0, 0.8],
     })
     expected = pd.DataFrame({
-        'Synthesizer': ['GaussianCopulaSynthesizer'],
-        'Train_Time': [1.0],
-        'Sample_Time': [2.0],
-        'Quality_Score': [1.0],
-        'Adjusted_Total_Time': [None],
-        'Adjusted_Quality_Score': [None],
+        'Synthesizer': ['GaussianCopulaSynthesizer', 'CTGANSynthesizer'],
+        'Train_Time': [1.0, 3.0],
+        'Sample_Time': [2.0, 1.0],
+        'Quality_Score': [1.0, 0.8],
+        'Adjusted_Total_Time': [None, None],
+        'Adjusted_Quality_Score': [None, None],
     })
 
     # Run


### PR DESCRIPTION
Resolve #461
CU-86b7855qp

[Here](https://us-east-1.console.aws.amazon.com/s3/object/sdgym-benchmark?region=us-east-1&bucketType=general&prefix=Debug/SDGym_results_10_27_2025/results%281%29.csv) is a run with a timeout of 20 seconds. As shown in this table, there is a Synthesizer Timeout for TVAESynthesizer and expedia_hotel_logs, and the `Adjusted Time` and `Adjusted Quality Score` are calculated.