### PR TITLE
EC2 instance not terminating after timeout

### DIFF
--- a/sdgym/benchmark.py
+++ b/sdgym/benchmark.py
@@ -1429,7 +1429,7 @@ def _get_user_data_script(access_key, secret_key, region_name, script_content):
 
         echo "======== Install Dependencies in venv ============"
         pip install --upgrade pip
-        pip install "sdgym[all] @ git+https://github.com/sdv-dev/SDGym.git@issue-463-terminate-instance-timeout"
+        pip install sdgym[all]
         pip install s3fs
 
         echo "======== Write Script ==========="


### PR DESCRIPTION
Resolve #463
CU-86b785fdq

I tried process.kill(), but it didn't work. The best solution I found is to forcefully terminate the instance regardless of the script's exit code, even if it's an error (a non-zero exit code). This way, we're safe from instances that do not shut down if an error occurs. For the timeout case, the exit code is 134. [here](https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#InstanceAudit:instanceId=i-02ed4bccae351e653;initialTabId=system-log) are the logs of the last machine I tested.