### PR TITLE
RealTabFormer 0.2.4 causes integration to fail

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ sdgym = { main = 'sdgym.cli.__main__:main' }
 [project.optional-dependencies]
 dask = ['dask', 'distributed']
 realtabformer = [
-    'realtabformer>=0.2.3',
+    'realtabformer>=0.2.3,!=0.2.4',
     "torch>=2.6.0",
     'transformers<4.51',
 ]

--- a/sdgym/synthesizers/realtabformer.py
+++ b/sdgym/synthesizers/realtabformer.py
@@ -1,7 +1,6 @@
 """REaLTabFormer integration."""
 
 import contextlib
-import inspect
 import logging
 from functools import partialmethod
 
@@ -38,15 +37,7 @@ class RealTabFormerSynthesizer(BaselineSynthesizer):
         with prevent_tqdm_output():
             model_kwargs = self._MODEL_KWARGS.copy() if self._MODEL_KWARGS else {}
             model = REaLTabFormer(model_type='tabular', **model_kwargs)
-
-            # RealTabFormer >=0.2.3 changed the default behavior of `fit` by introducing
-            # `save_full_every_epoch` and `gen_kwargs`. The new defaults break the SDGym
-            # end-to-end test, so we set them explicitly to preserve the previous behavior.
-            fit_sig = inspect.signature(model.fit)
-            if {'save_full_every_epoch', 'gen_kwargs'} <= fit_sig.parameters.keys():
-                model.fit(data, save_full_every_epoch=0, gen_kwargs={})
-            else:
-                model.fit(data)
+            model.fit(data)
 
             return model
 

--- a/tests/unit/synthesizers/test_realtabformer.py
+++ b/tests/unit/synthesizers/test_realtabformer.py
@@ -1,6 +1,6 @@
 """Tests for the realtabformer module."""
 
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pandas as pd
@@ -44,33 +44,6 @@ class TestRealTabFormerSynthesizer:
         mock_real_tab_former.assert_called_once_with(model_type='tabular')
         mock_model.fit.assert_called_once_with(data)
         assert result == mock_model, 'Expected the trained model to be returned.'
-
-    @patch('realtabformer.REaLTabFormer')
-    @patch('sdgym.synthesizers.realtabformer.inspect')
-    def test__get_trained_synthesizer_with_fit_parameters(self, mock_inspect, mock_real_tab_former):
-        """Test _get_trained_synthesizer when fit has extra parameters."""
-        # Setup
-        mock_inspect.signature.return_value.parameters = {
-            'save_full_every_epoch': None,
-            'gen_kwargs': None,
-            'other_param': None,
-        }
-        mock_model = Mock()
-        mock_real_tab_former.return_value = mock_model
-
-        data = Mock()
-        metadata = Mock()
-        synthesizer = RealTabFormerSynthesizer()
-        synthesizer._MODEL_KWARGS = {'epochs': 5}
-
-        # Run
-        result = synthesizer._get_trained_synthesizer(data, metadata)
-
-        # Assert
-        mock_real_tab_former.assert_called_once_with(model_type='tabular', epochs=5)
-        mock_model.fit.assert_called_once_with(data, save_full_every_epoch=0, gen_kwargs={})
-        mock_inspect.signature.assert_called_once_with(mock_model.fit)
-        assert result is mock_model
 
     def test__sample_from_synthesizer(self):
         """Test _sample_from_synthesizer generates data with the specified sample size."""


### PR DESCRIPTION
Resolve #523
CU-86b81pd3u

Early in `fit()` there is a call to [_train_with_sensitivity](https://github.com/worldbank/REaLTabFormer/blob/73f239643f9ea5abc877f685ce927e986302ac2d/src/realtabformer/realtabformer.py#L518) that leads to a few inconsistencies:
In `_train_with_sensitivity` there are:

```python
gen_df = self.sample(
    n_samples=gen_rounds * gen_total, device=device, **gen_kwargs
)
```
While `gen_kwargs` is None by default. This is the error of the issue.

Then if `save_full_every_epoch` is not 0 then we try to save the model at some epoch. Their save method expect an `self.experiment_id` to be set while the attribute is set at the end of `fit()` only, so it crashes. The default value for `save_full_every_epoch` is 5

I hope they will fix those inconsistencies in future releases so we can return to the previous implementation.

@amontanez24 This highlights a case we might consider in the future, distinguishing model parameters from `fit()/sample() ` parameters when defining a `wrapper/variant`. But I think it's out of scope for this issue.
