### PR TITLE
Latest PyTorch (2.11.0) is not compatible with current GCP GPU benchmark environment

### DIFF
--- a/sdgym/_benchmark_launcher/benchmark_base.yaml
+++ b/sdgym/_benchmark_launcher/benchmark_base.yaml
@@ -6,7 +6,7 @@ method_params:
 compute:
   service: gcp
   instance_type: n1-highmem-16
-  boot_image: projects/deeplearning-platform-release/global/images/family/common-cu128-ubuntu-2204-nvidia-570
+  boot_image: projects/deeplearning-platform-release/global/images/family/common-cu129-ubuntu-2204-nvidia-580
   root_disk_gb: 300
   gpu_type: nvidia-tesla-t4
   gpu_count: 1

--- a/sdgym/synthesizer_descriptions.yaml
+++ b/sdgym/synthesizer_descriptions.yaml
@@ -103,3 +103,34 @@ DataIdentity:
   description: >
     Degenerate synthesizer that returns the original training data unchanged,
     primarily useful for debugging and benchmarking.
+
+BootstrapSynthesizer:
+  library: sdv
+  organization: Datacebo
+  modality: single_table
+  type: Statistical
+  description: >
+    The BootstrapSynthesizer is a synthesizer specifically designed to work when you only have a few rows of data.
+    This synthesizer internally bootstraps your real data, and then uses the bootstrapped data to build a model.
+
+SegmentSynthesizer:
+  library: sdv
+  organization: Datacebo
+  modality: single_table
+  type: Statistical
+  description: >
+    The SegmentSynthesizer calculates different segments of real data,
+    and computes a different model for each one. You can supply any single-table
+    synthesizer for computing the per-segment model. Use this when your real data
+    is highly segmented, containing different patterns for each.
+
+XGCSynthesizer:
+  library: sdv
+  organization: Datacebo
+  modality: single_table
+  type: Statistical
+  description: >
+    The XGCSynthesizer stands for eXtraGaussianCopula. It uses classic, statistical methods
+    to train a model and generate synthetic data similar to the GaussianCopulaSynthesizer.
+    However, it contains some additional features for higher quality modeling.
+


### PR DESCRIPTION
Resolve #589
CU-86b9atcr2

The boot image used by the benchmark stopped being supported by Google on April 13, which caused this error:
```python
NotFound: 404 POST https://compute.googleapis.com/compute/v1/projects/sdgym-337614/zones/us-central1-a/instances: The resource 'projects/deeplearning-platform-release/global/images/family/common-cu128-ubuntu-2204-nvidia-570' was not found
```

I’m sharing below a screenshot of Google’s machine image lifecycle table. Based on it, I updated the boot image to common-`cu129-ubuntu-2204-nvidia-580`, which is the closest supported replacement to the one we were using. This image is supported until `August 4, 2028`.

I tested the change by running RealTabFormer with the new image, and it worked. The results are available [here](https://us-east-1.console.aws.amazon.com/s3/buckets/sdgym-benchmark?region=us-east-1&prefix=Debug/Issue_589/single_table/SDGym_results_04_15_2026/&showversions=false).

I also added a comment to the original issue to mention the boot image update and note that it resolves the original PyTorch/CUDA version conflict simultaneously.

<img width="1421" height="922" alt="Screenshot 2026-04-15 at 13 39 46" src="https://github.com/user-attachments/assets/a61df547-e404-446f-8ff8-0a645153c1d6" />


